### PR TITLE
Compiler Optimization Hints; Timing host <-> device data transfer cost etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CXX = dpcpp
 CXXFLAGS = -Wall -std=c++20
 SYCLFLAGS = -fsycl
 SYCLCUDAFLAGS = -fsycl-targets=nvptx64-nvidia-cuda
+OPTFLAGS = -O3
 IFLAGS = -I ./include
 LFLAGS = -L ./test/target/release -lblake3_test -lpthread
 BLAKE3_SIMD_LANES_FLAGS = -DBLAKE3_SIMD_LANES=$(shell echo $(or $(BLAKE3_SIMD_LANES),4)) # allowed values from set {2, 4, 8, 16}; default set to 4
@@ -25,7 +26,7 @@ format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla
 
 bench/a.out: bench/main.cpp include/bench_blake3.hpp
-	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) $< -o $@
 
 benchmark: bench/a.out
 	./bench/a.out
@@ -33,25 +34,25 @@ benchmark: bench/a.out
 aot_cpu:
 	@if lscpu | grep -q 'avx512'; then \
 		echo "Using avx512"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx512" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx512" bench/main.cpp -o bench/a.out; \
 	elif lscpu | grep -q 'avx2'; then \
 		echo "Using avx2"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx2" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx2" bench/main.cpp -o bench/a.out; \
 	elif lscpu | grep -q 'avx'; then \
 		echo "Using avx"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx" bench/main.cpp -o bench/a.out; \
 	elif lscpu | grep -q 'sse4.2'; then \
 		echo "Using sse4.2"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=sse4.2" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=sse4.2" bench/main.cpp -o bench/a.out; \
 	else \
 		echo "Can't AOT compile using avx, avx2, avx512 or sse4.2"; \
 	fi
 	./bench/a.out
 
 aot_gpu:
-	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_gen -Xs "-device 0x4905" bench/main.cpp -o bench/a.out
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_gen -Xs "-device 0x4905" bench/main.cpp -o bench/a.out
 	./bench/a.out
 
 cuda:
-	clang++ $(CXXFLAGS) $(SYCLFLAGS) $(SYCLCUDAFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) bench/main.cpp -o bench/a.out
+	clang++ $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(SYCLCUDAFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) bench/main.cpp -o bench/a.out
 	./bench/a.out

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ aot_cpu:
 	./bench/a.out
 
 aot_gpu:
+	# you may want to replace `device` identifier with `0x3e96` if you're targeting *Intel(R) UHD Graphics P630*
+	#
+	# otherwise, let it be what it's if you're targeting *Intel(R) Iris(R) Xe MAX Graphics*
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(OPTFLAGS) $(IFLAGS) $(BLAKE3_SIMD_LANES_FLAGS) -fsycl-targets=spir64_gen -Xs "-device 0x4905" bench/main.cpp -o bench/a.out
 	./bench/a.out
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,13 @@ docker run blake3-test
 
 ## Benchmark
 
-Following benchmark results denote what was only kernel execution time ( on accelerator ) when computing BLAKE3 hash ( v1 & v2 ) using SYCL implementation and input was of given size on first column. Input is prepared on host; then explicitly transferred to accelerator because I'm using `sycl::malloc_host` and `sycl::malloc_device` for heap allocation; finally computed BLAKE3 digest ( i.e. 32 -bytes ) is transferred back to host. Though none of these data transfer cost are included in following numbers presented. For benchmarking purposes, I enable profiling in SYCL queue and sum of all differences between kernel enqueue event's start and end times are taken. I've also used a SYCL work-group size of 32 for each of these executions rounds; total of 4 rounds are executed for each row before taking average of obtained kernel execution time.
+Following benchmark results denote what was 
+
+- kernel execution time
+- time required to transfer input bytes to device
+- time needed to transfer 32 -bytes digest back to host
+
+when computing BLAKE3 hash ( v1 & v2 ) using SYCL implementation and input was of given size on first column. Input is generated on host; then explicitly transferred to accelerator because I'm using `sycl::malloc_host` and `sycl::malloc_device` for heap allocation; finally computed BLAKE3 digest ( i.e. 32 -bytes ) is transferred back to host. *None of these data transfer costs are included in kernel execution time*. For benchmarking purposes, I enable profiling in SYCL queue and sum of all differences between kernel enqueue event's start and end times are taken. I've also used a SYCL work-group size of 32 for each of these executions rounds; total of 8 rounds are executed for each row before taking average of obtained kernel execution time/ host <-> device data transfer time.
 
 - [On Nvidia GPU](./results/nvidia_gpu.md)
 - [On Intel GPU](./results/intel_gpu.md)

--- a/include/blake3.hpp
+++ b/include/blake3.hpp
@@ -178,41 +178,41 @@ blake3::v2::g(
   size_t c,
   size_t d,
 #if BLAKE3_SIMD_LANES == 2
-  sycl::uint2 mx,
-  sycl::uint2 my
+  const sycl::uint2 mx,
+  const sycl::uint2 my
 #elif BLAKE3_SIMD_LANES == 4
-  sycl::uint4 mx,
-  sycl::uint4 my
+  const sycl::uint4 mx,
+  const sycl::uint4 my
 #elif BLAKE3_SIMD_LANES == 8
-  sycl::uint8 mx,
-  sycl::uint8 my
+  const sycl::uint8 mx,
+  const sycl::uint8 my
 #elif BLAKE3_SIMD_LANES == 16
-  sycl::uint16 mx,
-  sycl::uint16 my
+  const sycl::uint16 mx,
+  const sycl::uint16 my
 #endif
 )
 {
 
 #if BLAKE3_SIMD_LANES == 2
-  sycl::uint2 rrot16 = sycl::uint2(16);
-  sycl::uint2 rrot12 = sycl::uint2(20);
-  sycl::uint2 rrot8 = sycl::uint2(24);
-  sycl::uint2 rrot7 = sycl::uint2(25);
+  const sycl::uint2 rrot16 = sycl::uint2(16);
+  const sycl::uint2 rrot12 = sycl::uint2(20);
+  const sycl::uint2 rrot8 = sycl::uint2(24);
+  const sycl::uint2 rrot7 = sycl::uint2(25);
 #elif BLAKE3_SIMD_LANES == 4
-  sycl::uint4 rrot16 = sycl::uint4(16);
-  sycl::uint4 rrot12 = sycl::uint4(20);
-  sycl::uint4 rrot8 = sycl::uint4(24);
-  sycl::uint4 rrot7 = sycl::uint4(25);
+  const sycl::uint4 rrot16 = sycl::uint4(16);
+  const sycl::uint4 rrot12 = sycl::uint4(20);
+  const sycl::uint4 rrot8 = sycl::uint4(24);
+  const sycl::uint4 rrot7 = sycl::uint4(25);
 #elif BLAKE3_SIMD_LANES == 8
-  sycl::uint8 rrot16 = sycl::uint8(16);
-  sycl::uint8 rrot12 = sycl::uint8(20);
-  sycl::uint8 rrot8 = sycl::uint8(24);
-  sycl::uint8 rrot7 = sycl::uint8(25);
+  const sycl::uint8 rrot16 = sycl::uint8(16);
+  const sycl::uint8 rrot12 = sycl::uint8(20);
+  const sycl::uint8 rrot8 = sycl::uint8(24);
+  const sycl::uint8 rrot7 = sycl::uint8(25);
 #elif BLAKE3_SIMD_LANES == 16
-  sycl::uint16 rrot16 = sycl::uint16(16);
-  sycl::uint16 rrot12 = sycl::uint16(20);
-  sycl::uint16 rrot8 = sycl::uint16(24);
-  sycl::uint16 rrot7 = sycl::uint16(25);
+  const sycl::uint16 rrot16 = sycl::uint16(16);
+  const sycl::uint16 rrot12 = sycl::uint16(20);
+  const sycl::uint16 rrot8 = sycl::uint16(24);
+  const sycl::uint16 rrot7 = sycl::uint16(25);
 #endif
 
   *(state + a) = *(state + a) + *(state + b) + mx;
@@ -241,67 +241,69 @@ blake3::v2::round(
   // column-wise hash state manipulation starts
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 0), *(msg + 16 * 1 + 0));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 1), *(msg + 16 * 1 + 1));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 0), *(msg + 16 * 1 + 0));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 1), *(msg + 16 * 1 + 1));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 0),
-                                 *(msg + 16 * 1 + 0),
-                                 *(msg + 16 * 2 + 0),
-                                 *(msg + 16 * 3 + 0));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 1),
-                                 *(msg + 16 * 1 + 1),
-                                 *(msg + 16 * 2 + 1),
-                                 *(msg + 16 * 3 + 1));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 0),
+                                       *(msg + 16 * 1 + 0),
+                                       *(msg + 16 * 2 + 0),
+                                       *(msg + 16 * 3 + 0));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 1),
+                                       *(msg + 16 * 1 + 1),
+                                       *(msg + 16 * 2 + 1),
+                                       *(msg + 16 * 3 + 1));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 0),
-                                 *(msg + 16 * 1 + 0),
-                                 *(msg + 16 * 2 + 0),
-                                 *(msg + 16 * 3 + 0),
-                                 *(msg + 16 * 4 + 0),
-                                 *(msg + 16 * 5 + 0),
-                                 *(msg + 16 * 6 + 0),
-                                 *(msg + 16 * 7 + 0));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 1),
-                                 *(msg + 16 * 1 + 1),
-                                 *(msg + 16 * 2 + 1),
-                                 *(msg + 16 * 3 + 1),
-                                 *(msg + 16 * 4 + 1),
-                                 *(msg + 16 * 5 + 1),
-                                 *(msg + 16 * 6 + 1),
-                                 *(msg + 16 * 7 + 1));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 0),
+                                       *(msg + 16 * 1 + 0),
+                                       *(msg + 16 * 2 + 0),
+                                       *(msg + 16 * 3 + 0),
+                                       *(msg + 16 * 4 + 0),
+                                       *(msg + 16 * 5 + 0),
+                                       *(msg + 16 * 6 + 0),
+                                       *(msg + 16 * 7 + 0));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 1),
+                                       *(msg + 16 * 1 + 1),
+                                       *(msg + 16 * 2 + 1),
+                                       *(msg + 16 * 3 + 1),
+                                       *(msg + 16 * 4 + 1),
+                                       *(msg + 16 * 5 + 1),
+                                       *(msg + 16 * 6 + 1),
+                                       *(msg + 16 * 7 + 1));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 0),
-                                   *(msg + 16 * 1 + 0),
-                                   *(msg + 16 * 2 + 0),
-                                   *(msg + 16 * 3 + 0),
-                                   *(msg + 16 * 4 + 0),
-                                   *(msg + 16 * 5 + 0),
-                                   *(msg + 16 * 6 + 0),
-                                   *(msg + 16 * 7 + 0),
-                                   *(msg + 16 * 8 + 0),
-                                   *(msg + 16 * 9 + 0),
-                                   *(msg + 16 * 10 + 0),
-                                   *(msg + 16 * 11 + 0),
-                                   *(msg + 16 * 12 + 0),
-                                   *(msg + 16 * 13 + 0),
-                                   *(msg + 16 * 14 + 0),
-                                   *(msg + 16 * 15 + 0));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 1),
-                                   *(msg + 16 * 1 + 1),
-                                   *(msg + 16 * 2 + 1),
-                                   *(msg + 16 * 3 + 1),
-                                   *(msg + 16 * 4 + 1),
-                                   *(msg + 16 * 5 + 1),
-                                   *(msg + 16 * 6 + 1),
-                                   *(msg + 16 * 7 + 1),
-                                   *(msg + 16 * 8 + 1),
-                                   *(msg + 16 * 9 + 1),
-                                   *(msg + 16 * 10 + 1),
-                                   *(msg + 16 * 11 + 1),
-                                   *(msg + 16 * 12 + 1),
-                                   *(msg + 16 * 13 + 1),
-                                   *(msg + 16 * 14 + 1),
-                                   *(msg + 16 * 15 + 1));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 0),
+                                         *(msg + 16 * 1 + 0),
+                                         *(msg + 16 * 2 + 0),
+                                         *(msg + 16 * 3 + 0),
+                                         *(msg + 16 * 4 + 0),
+                                         *(msg + 16 * 5 + 0),
+                                         *(msg + 16 * 6 + 0),
+                                         *(msg + 16 * 7 + 0),
+                                         *(msg + 16 * 8 + 0),
+                                         *(msg + 16 * 9 + 0),
+                                         *(msg + 16 * 10 + 0),
+                                         *(msg + 16 * 11 + 0),
+                                         *(msg + 16 * 12 + 0),
+                                         *(msg + 16 * 13 + 0),
+                                         *(msg + 16 * 14 + 0),
+                                         *(msg + 16 * 15 + 0));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 1),
+                                         *(msg + 16 * 1 + 1),
+                                         *(msg + 16 * 2 + 1),
+                                         *(msg + 16 * 3 + 1),
+                                         *(msg + 16 * 4 + 1),
+                                         *(msg + 16 * 5 + 1),
+                                         *(msg + 16 * 6 + 1),
+                                         *(msg + 16 * 7 + 1),
+                                         *(msg + 16 * 8 + 1),
+                                         *(msg + 16 * 9 + 1),
+                                         *(msg + 16 * 10 + 1),
+                                         *(msg + 16 * 11 + 1),
+                                         *(msg + 16 * 12 + 1),
+                                         *(msg + 16 * 13 + 1),
+                                         *(msg + 16 * 14 + 1),
+                                         *(msg + 16 * 15 + 1));
 #endif
 
     blake3::v2::g(state, 0, 4, 8, 12, mx, my);
@@ -309,67 +311,69 @@ blake3::v2::round(
 
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 2), *(msg + 16 * 1 + 2));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 3), *(msg + 16 * 1 + 3));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 2), *(msg + 16 * 1 + 2));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 3), *(msg + 16 * 1 + 3));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 2),
-                                 *(msg + 16 * 1 + 2),
-                                 *(msg + 16 * 2 + 2),
-                                 *(msg + 16 * 3 + 2));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 3),
-                                 *(msg + 16 * 1 + 3),
-                                 *(msg + 16 * 2 + 3),
-                                 *(msg + 16 * 3 + 3));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 2),
+                                       *(msg + 16 * 1 + 2),
+                                       *(msg + 16 * 2 + 2),
+                                       *(msg + 16 * 3 + 2));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 3),
+                                       *(msg + 16 * 1 + 3),
+                                       *(msg + 16 * 2 + 3),
+                                       *(msg + 16 * 3 + 3));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 2),
-                                 *(msg + 16 * 1 + 2),
-                                 *(msg + 16 * 2 + 2),
-                                 *(msg + 16 * 3 + 2),
-                                 *(msg + 16 * 4 + 2),
-                                 *(msg + 16 * 5 + 2),
-                                 *(msg + 16 * 6 + 2),
-                                 *(msg + 16 * 7 + 2));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 3),
-                                 *(msg + 16 * 1 + 3),
-                                 *(msg + 16 * 2 + 3),
-                                 *(msg + 16 * 3 + 3),
-                                 *(msg + 16 * 4 + 3),
-                                 *(msg + 16 * 5 + 3),
-                                 *(msg + 16 * 6 + 3),
-                                 *(msg + 16 * 7 + 3));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 2),
+                                       *(msg + 16 * 1 + 2),
+                                       *(msg + 16 * 2 + 2),
+                                       *(msg + 16 * 3 + 2),
+                                       *(msg + 16 * 4 + 2),
+                                       *(msg + 16 * 5 + 2),
+                                       *(msg + 16 * 6 + 2),
+                                       *(msg + 16 * 7 + 2));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 3),
+                                       *(msg + 16 * 1 + 3),
+                                       *(msg + 16 * 2 + 3),
+                                       *(msg + 16 * 3 + 3),
+                                       *(msg + 16 * 4 + 3),
+                                       *(msg + 16 * 5 + 3),
+                                       *(msg + 16 * 6 + 3),
+                                       *(msg + 16 * 7 + 3));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 2),
-                                   *(msg + 16 * 1 + 2),
-                                   *(msg + 16 * 2 + 2),
-                                   *(msg + 16 * 3 + 2),
-                                   *(msg + 16 * 4 + 2),
-                                   *(msg + 16 * 5 + 2),
-                                   *(msg + 16 * 6 + 2),
-                                   *(msg + 16 * 7 + 2),
-                                   *(msg + 16 * 8 + 2),
-                                   *(msg + 16 * 9 + 2),
-                                   *(msg + 16 * 10 + 2),
-                                   *(msg + 16 * 11 + 2),
-                                   *(msg + 16 * 12 + 2),
-                                   *(msg + 16 * 13 + 2),
-                                   *(msg + 16 * 14 + 2),
-                                   *(msg + 16 * 15 + 2));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 3),
-                                   *(msg + 16 * 1 + 3),
-                                   *(msg + 16 * 2 + 3),
-                                   *(msg + 16 * 3 + 3),
-                                   *(msg + 16 * 4 + 3),
-                                   *(msg + 16 * 5 + 3),
-                                   *(msg + 16 * 6 + 3),
-                                   *(msg + 16 * 7 + 3),
-                                   *(msg + 16 * 8 + 3),
-                                   *(msg + 16 * 9 + 3),
-                                   *(msg + 16 * 10 + 3),
-                                   *(msg + 16 * 11 + 3),
-                                   *(msg + 16 * 12 + 3),
-                                   *(msg + 16 * 13 + 3),
-                                   *(msg + 16 * 14 + 3),
-                                   *(msg + 16 * 15 + 3));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 2),
+                                         *(msg + 16 * 1 + 2),
+                                         *(msg + 16 * 2 + 2),
+                                         *(msg + 16 * 3 + 2),
+                                         *(msg + 16 * 4 + 2),
+                                         *(msg + 16 * 5 + 2),
+                                         *(msg + 16 * 6 + 2),
+                                         *(msg + 16 * 7 + 2),
+                                         *(msg + 16 * 8 + 2),
+                                         *(msg + 16 * 9 + 2),
+                                         *(msg + 16 * 10 + 2),
+                                         *(msg + 16 * 11 + 2),
+                                         *(msg + 16 * 12 + 2),
+                                         *(msg + 16 * 13 + 2),
+                                         *(msg + 16 * 14 + 2),
+                                         *(msg + 16 * 15 + 2));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 3),
+                                         *(msg + 16 * 1 + 3),
+                                         *(msg + 16 * 2 + 3),
+                                         *(msg + 16 * 3 + 3),
+                                         *(msg + 16 * 4 + 3),
+                                         *(msg + 16 * 5 + 3),
+                                         *(msg + 16 * 6 + 3),
+                                         *(msg + 16 * 7 + 3),
+                                         *(msg + 16 * 8 + 3),
+                                         *(msg + 16 * 9 + 3),
+                                         *(msg + 16 * 10 + 3),
+                                         *(msg + 16 * 11 + 3),
+                                         *(msg + 16 * 12 + 3),
+                                         *(msg + 16 * 13 + 3),
+                                         *(msg + 16 * 14 + 3),
+                                         *(msg + 16 * 15 + 3));
 #endif
 
     blake3::v2::g(state, 1, 5, 9, 13, mx, my);
@@ -377,67 +381,69 @@ blake3::v2::round(
 
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 4), *(msg + 16 * 1 + 4));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 5), *(msg + 16 * 1 + 5));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 4), *(msg + 16 * 1 + 4));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 5), *(msg + 16 * 1 + 5));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 4),
-                                 *(msg + 16 * 1 + 4),
-                                 *(msg + 16 * 2 + 4),
-                                 *(msg + 16 * 3 + 4));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 5),
-                                 *(msg + 16 * 1 + 5),
-                                 *(msg + 16 * 2 + 5),
-                                 *(msg + 16 * 3 + 5));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 4),
+                                       *(msg + 16 * 1 + 4),
+                                       *(msg + 16 * 2 + 4),
+                                       *(msg + 16 * 3 + 4));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 5),
+                                       *(msg + 16 * 1 + 5),
+                                       *(msg + 16 * 2 + 5),
+                                       *(msg + 16 * 3 + 5));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 4),
-                                 *(msg + 16 * 1 + 4),
-                                 *(msg + 16 * 2 + 4),
-                                 *(msg + 16 * 3 + 4),
-                                 *(msg + 16 * 4 + 4),
-                                 *(msg + 16 * 5 + 4),
-                                 *(msg + 16 * 6 + 4),
-                                 *(msg + 16 * 7 + 4));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 5),
-                                 *(msg + 16 * 1 + 5),
-                                 *(msg + 16 * 2 + 5),
-                                 *(msg + 16 * 3 + 5),
-                                 *(msg + 16 * 4 + 5),
-                                 *(msg + 16 * 5 + 5),
-                                 *(msg + 16 * 6 + 5),
-                                 *(msg + 16 * 7 + 5));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 4),
+                                       *(msg + 16 * 1 + 4),
+                                       *(msg + 16 * 2 + 4),
+                                       *(msg + 16 * 3 + 4),
+                                       *(msg + 16 * 4 + 4),
+                                       *(msg + 16 * 5 + 4),
+                                       *(msg + 16 * 6 + 4),
+                                       *(msg + 16 * 7 + 4));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 5),
+                                       *(msg + 16 * 1 + 5),
+                                       *(msg + 16 * 2 + 5),
+                                       *(msg + 16 * 3 + 5),
+                                       *(msg + 16 * 4 + 5),
+                                       *(msg + 16 * 5 + 5),
+                                       *(msg + 16 * 6 + 5),
+                                       *(msg + 16 * 7 + 5));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 4),
-                                   *(msg + 16 * 1 + 4),
-                                   *(msg + 16 * 2 + 4),
-                                   *(msg + 16 * 3 + 4),
-                                   *(msg + 16 * 4 + 4),
-                                   *(msg + 16 * 5 + 4),
-                                   *(msg + 16 * 6 + 4),
-                                   *(msg + 16 * 7 + 4),
-                                   *(msg + 16 * 8 + 4),
-                                   *(msg + 16 * 9 + 4),
-                                   *(msg + 16 * 10 + 4),
-                                   *(msg + 16 * 11 + 4),
-                                   *(msg + 16 * 12 + 4),
-                                   *(msg + 16 * 13 + 4),
-                                   *(msg + 16 * 14 + 4),
-                                   *(msg + 16 * 15 + 4));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 5),
-                                   *(msg + 16 * 1 + 5),
-                                   *(msg + 16 * 2 + 5),
-                                   *(msg + 16 * 3 + 5),
-                                   *(msg + 16 * 4 + 5),
-                                   *(msg + 16 * 5 + 5),
-                                   *(msg + 16 * 6 + 5),
-                                   *(msg + 16 * 7 + 5),
-                                   *(msg + 16 * 8 + 5),
-                                   *(msg + 16 * 9 + 5),
-                                   *(msg + 16 * 10 + 5),
-                                   *(msg + 16 * 11 + 5),
-                                   *(msg + 16 * 12 + 5),
-                                   *(msg + 16 * 13 + 5),
-                                   *(msg + 16 * 14 + 5),
-                                   *(msg + 16 * 15 + 5));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 4),
+                                         *(msg + 16 * 1 + 4),
+                                         *(msg + 16 * 2 + 4),
+                                         *(msg + 16 * 3 + 4),
+                                         *(msg + 16 * 4 + 4),
+                                         *(msg + 16 * 5 + 4),
+                                         *(msg + 16 * 6 + 4),
+                                         *(msg + 16 * 7 + 4),
+                                         *(msg + 16 * 8 + 4),
+                                         *(msg + 16 * 9 + 4),
+                                         *(msg + 16 * 10 + 4),
+                                         *(msg + 16 * 11 + 4),
+                                         *(msg + 16 * 12 + 4),
+                                         *(msg + 16 * 13 + 4),
+                                         *(msg + 16 * 14 + 4),
+                                         *(msg + 16 * 15 + 4));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 5),
+                                         *(msg + 16 * 1 + 5),
+                                         *(msg + 16 * 2 + 5),
+                                         *(msg + 16 * 3 + 5),
+                                         *(msg + 16 * 4 + 5),
+                                         *(msg + 16 * 5 + 5),
+                                         *(msg + 16 * 6 + 5),
+                                         *(msg + 16 * 7 + 5),
+                                         *(msg + 16 * 8 + 5),
+                                         *(msg + 16 * 9 + 5),
+                                         *(msg + 16 * 10 + 5),
+                                         *(msg + 16 * 11 + 5),
+                                         *(msg + 16 * 12 + 5),
+                                         *(msg + 16 * 13 + 5),
+                                         *(msg + 16 * 14 + 5),
+                                         *(msg + 16 * 15 + 5));
 #endif
 
     blake3::v2::g(state, 2, 6, 10, 14, mx, my);
@@ -445,67 +451,69 @@ blake3::v2::round(
 
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 6), *(msg + 16 * 1 + 6));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 7), *(msg + 16 * 1 + 7));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 6), *(msg + 16 * 1 + 6));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 7), *(msg + 16 * 1 + 7));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 6),
-                                 *(msg + 16 * 1 + 6),
-                                 *(msg + 16 * 2 + 6),
-                                 *(msg + 16 * 3 + 6));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 7),
-                                 *(msg + 16 * 1 + 7),
-                                 *(msg + 16 * 2 + 7),
-                                 *(msg + 16 * 3 + 7));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 6),
+                                       *(msg + 16 * 1 + 6),
+                                       *(msg + 16 * 2 + 6),
+                                       *(msg + 16 * 3 + 6));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 7),
+                                       *(msg + 16 * 1 + 7),
+                                       *(msg + 16 * 2 + 7),
+                                       *(msg + 16 * 3 + 7));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 6),
-                                 *(msg + 16 * 1 + 6),
-                                 *(msg + 16 * 2 + 6),
-                                 *(msg + 16 * 3 + 6),
-                                 *(msg + 16 * 4 + 6),
-                                 *(msg + 16 * 5 + 6),
-                                 *(msg + 16 * 6 + 6),
-                                 *(msg + 16 * 7 + 6));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 7),
-                                 *(msg + 16 * 1 + 7),
-                                 *(msg + 16 * 2 + 7),
-                                 *(msg + 16 * 3 + 7),
-                                 *(msg + 16 * 4 + 7),
-                                 *(msg + 16 * 5 + 7),
-                                 *(msg + 16 * 6 + 7),
-                                 *(msg + 16 * 7 + 7));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 6),
+                                       *(msg + 16 * 1 + 6),
+                                       *(msg + 16 * 2 + 6),
+                                       *(msg + 16 * 3 + 6),
+                                       *(msg + 16 * 4 + 6),
+                                       *(msg + 16 * 5 + 6),
+                                       *(msg + 16 * 6 + 6),
+                                       *(msg + 16 * 7 + 6));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 7),
+                                       *(msg + 16 * 1 + 7),
+                                       *(msg + 16 * 2 + 7),
+                                       *(msg + 16 * 3 + 7),
+                                       *(msg + 16 * 4 + 7),
+                                       *(msg + 16 * 5 + 7),
+                                       *(msg + 16 * 6 + 7),
+                                       *(msg + 16 * 7 + 7));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 6),
-                                   *(msg + 16 * 1 + 6),
-                                   *(msg + 16 * 2 + 6),
-                                   *(msg + 16 * 3 + 6),
-                                   *(msg + 16 * 4 + 6),
-                                   *(msg + 16 * 5 + 6),
-                                   *(msg + 16 * 6 + 6),
-                                   *(msg + 16 * 7 + 6),
-                                   *(msg + 16 * 8 + 6),
-                                   *(msg + 16 * 9 + 6),
-                                   *(msg + 16 * 10 + 6),
-                                   *(msg + 16 * 11 + 6),
-                                   *(msg + 16 * 12 + 6),
-                                   *(msg + 16 * 13 + 6),
-                                   *(msg + 16 * 14 + 6),
-                                   *(msg + 16 * 15 + 6));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 7),
-                                   *(msg + 16 * 1 + 7),
-                                   *(msg + 16 * 2 + 7),
-                                   *(msg + 16 * 3 + 7),
-                                   *(msg + 16 * 4 + 7),
-                                   *(msg + 16 * 5 + 7),
-                                   *(msg + 16 * 6 + 7),
-                                   *(msg + 16 * 7 + 7),
-                                   *(msg + 16 * 8 + 7),
-                                   *(msg + 16 * 9 + 7),
-                                   *(msg + 16 * 10 + 7),
-                                   *(msg + 16 * 11 + 7),
-                                   *(msg + 16 * 12 + 7),
-                                   *(msg + 16 * 13 + 7),
-                                   *(msg + 16 * 14 + 7),
-                                   *(msg + 16 * 15 + 7));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 6),
+                                         *(msg + 16 * 1 + 6),
+                                         *(msg + 16 * 2 + 6),
+                                         *(msg + 16 * 3 + 6),
+                                         *(msg + 16 * 4 + 6),
+                                         *(msg + 16 * 5 + 6),
+                                         *(msg + 16 * 6 + 6),
+                                         *(msg + 16 * 7 + 6),
+                                         *(msg + 16 * 8 + 6),
+                                         *(msg + 16 * 9 + 6),
+                                         *(msg + 16 * 10 + 6),
+                                         *(msg + 16 * 11 + 6),
+                                         *(msg + 16 * 12 + 6),
+                                         *(msg + 16 * 13 + 6),
+                                         *(msg + 16 * 14 + 6),
+                                         *(msg + 16 * 15 + 6));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 7),
+                                         *(msg + 16 * 1 + 7),
+                                         *(msg + 16 * 2 + 7),
+                                         *(msg + 16 * 3 + 7),
+                                         *(msg + 16 * 4 + 7),
+                                         *(msg + 16 * 5 + 7),
+                                         *(msg + 16 * 6 + 7),
+                                         *(msg + 16 * 7 + 7),
+                                         *(msg + 16 * 8 + 7),
+                                         *(msg + 16 * 9 + 7),
+                                         *(msg + 16 * 10 + 7),
+                                         *(msg + 16 * 11 + 7),
+                                         *(msg + 16 * 12 + 7),
+                                         *(msg + 16 * 13 + 7),
+                                         *(msg + 16 * 14 + 7),
+                                         *(msg + 16 * 15 + 7));
 #endif
 
     blake3::v2::g(state, 3, 7, 11, 15, mx, my);
@@ -515,67 +523,69 @@ blake3::v2::round(
   // diagonal hash state manipulation starts
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 8), *(msg + 16 * 1 + 8));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 9), *(msg + 16 * 1 + 9));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 8), *(msg + 16 * 1 + 8));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 9), *(msg + 16 * 1 + 9));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 8),
-                                 *(msg + 16 * 1 + 8),
-                                 *(msg + 16 * 2 + 8),
-                                 *(msg + 16 * 3 + 8));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 9),
-                                 *(msg + 16 * 1 + 9),
-                                 *(msg + 16 * 2 + 9),
-                                 *(msg + 16 * 3 + 9));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 8),
+                                       *(msg + 16 * 1 + 8),
+                                       *(msg + 16 * 2 + 8),
+                                       *(msg + 16 * 3 + 8));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 9),
+                                       *(msg + 16 * 1 + 9),
+                                       *(msg + 16 * 2 + 9),
+                                       *(msg + 16 * 3 + 9));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 8),
-                                 *(msg + 16 * 1 + 8),
-                                 *(msg + 16 * 2 + 8),
-                                 *(msg + 16 * 3 + 8),
-                                 *(msg + 16 * 4 + 8),
-                                 *(msg + 16 * 5 + 8),
-                                 *(msg + 16 * 6 + 8),
-                                 *(msg + 16 * 7 + 8));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 9),
-                                 *(msg + 16 * 1 + 9),
-                                 *(msg + 16 * 2 + 9),
-                                 *(msg + 16 * 3 + 9),
-                                 *(msg + 16 * 4 + 9),
-                                 *(msg + 16 * 5 + 9),
-                                 *(msg + 16 * 6 + 9),
-                                 *(msg + 16 * 7 + 9));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 8),
+                                       *(msg + 16 * 1 + 8),
+                                       *(msg + 16 * 2 + 8),
+                                       *(msg + 16 * 3 + 8),
+                                       *(msg + 16 * 4 + 8),
+                                       *(msg + 16 * 5 + 8),
+                                       *(msg + 16 * 6 + 8),
+                                       *(msg + 16 * 7 + 8));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 9),
+                                       *(msg + 16 * 1 + 9),
+                                       *(msg + 16 * 2 + 9),
+                                       *(msg + 16 * 3 + 9),
+                                       *(msg + 16 * 4 + 9),
+                                       *(msg + 16 * 5 + 9),
+                                       *(msg + 16 * 6 + 9),
+                                       *(msg + 16 * 7 + 9));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 8),
-                                   *(msg + 16 * 1 + 8),
-                                   *(msg + 16 * 2 + 8),
-                                   *(msg + 16 * 3 + 8),
-                                   *(msg + 16 * 4 + 8),
-                                   *(msg + 16 * 5 + 8),
-                                   *(msg + 16 * 6 + 8),
-                                   *(msg + 16 * 7 + 8),
-                                   *(msg + 16 * 8 + 8),
-                                   *(msg + 16 * 9 + 8),
-                                   *(msg + 16 * 10 + 8),
-                                   *(msg + 16 * 11 + 8),
-                                   *(msg + 16 * 12 + 8),
-                                   *(msg + 16 * 13 + 8),
-                                   *(msg + 16 * 14 + 8),
-                                   *(msg + 16 * 15 + 8));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 9),
-                                   *(msg + 16 * 1 + 9),
-                                   *(msg + 16 * 2 + 9),
-                                   *(msg + 16 * 3 + 9),
-                                   *(msg + 16 * 4 + 9),
-                                   *(msg + 16 * 5 + 9),
-                                   *(msg + 16 * 6 + 9),
-                                   *(msg + 16 * 7 + 9),
-                                   *(msg + 16 * 8 + 9),
-                                   *(msg + 16 * 9 + 9),
-                                   *(msg + 16 * 10 + 9),
-                                   *(msg + 16 * 11 + 9),
-                                   *(msg + 16 * 12 + 9),
-                                   *(msg + 16 * 13 + 9),
-                                   *(msg + 16 * 14 + 9),
-                                   *(msg + 16 * 15 + 9));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 8),
+                                         *(msg + 16 * 1 + 8),
+                                         *(msg + 16 * 2 + 8),
+                                         *(msg + 16 * 3 + 8),
+                                         *(msg + 16 * 4 + 8),
+                                         *(msg + 16 * 5 + 8),
+                                         *(msg + 16 * 6 + 8),
+                                         *(msg + 16 * 7 + 8),
+                                         *(msg + 16 * 8 + 8),
+                                         *(msg + 16 * 9 + 8),
+                                         *(msg + 16 * 10 + 8),
+                                         *(msg + 16 * 11 + 8),
+                                         *(msg + 16 * 12 + 8),
+                                         *(msg + 16 * 13 + 8),
+                                         *(msg + 16 * 14 + 8),
+                                         *(msg + 16 * 15 + 8));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 9),
+                                         *(msg + 16 * 1 + 9),
+                                         *(msg + 16 * 2 + 9),
+                                         *(msg + 16 * 3 + 9),
+                                         *(msg + 16 * 4 + 9),
+                                         *(msg + 16 * 5 + 9),
+                                         *(msg + 16 * 6 + 9),
+                                         *(msg + 16 * 7 + 9),
+                                         *(msg + 16 * 8 + 9),
+                                         *(msg + 16 * 9 + 9),
+                                         *(msg + 16 * 10 + 9),
+                                         *(msg + 16 * 11 + 9),
+                                         *(msg + 16 * 12 + 9),
+                                         *(msg + 16 * 13 + 9),
+                                         *(msg + 16 * 14 + 9),
+                                         *(msg + 16 * 15 + 9));
 #endif
 
     blake3::v2::g(state, 0, 5, 10, 15, mx, my);
@@ -583,67 +593,69 @@ blake3::v2::round(
 
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 10), *(msg + 16 * 1 + 10));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 11), *(msg + 16 * 1 + 11));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 10), *(msg + 16 * 1 + 10));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 11), *(msg + 16 * 1 + 11));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 10),
-                                 *(msg + 16 * 1 + 10),
-                                 *(msg + 16 * 2 + 10),
-                                 *(msg + 16 * 3 + 10));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 11),
-                                 *(msg + 16 * 1 + 11),
-                                 *(msg + 16 * 2 + 11),
-                                 *(msg + 16 * 3 + 11));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 10),
+                                       *(msg + 16 * 1 + 10),
+                                       *(msg + 16 * 2 + 10),
+                                       *(msg + 16 * 3 + 10));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 11),
+                                       *(msg + 16 * 1 + 11),
+                                       *(msg + 16 * 2 + 11),
+                                       *(msg + 16 * 3 + 11));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 10),
-                                 *(msg + 16 * 1 + 10),
-                                 *(msg + 16 * 2 + 10),
-                                 *(msg + 16 * 3 + 10),
-                                 *(msg + 16 * 4 + 10),
-                                 *(msg + 16 * 5 + 10),
-                                 *(msg + 16 * 6 + 10),
-                                 *(msg + 16 * 7 + 10));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 11),
-                                 *(msg + 16 * 1 + 11),
-                                 *(msg + 16 * 2 + 11),
-                                 *(msg + 16 * 3 + 11),
-                                 *(msg + 16 * 4 + 11),
-                                 *(msg + 16 * 5 + 11),
-                                 *(msg + 16 * 6 + 11),
-                                 *(msg + 16 * 7 + 11));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 10),
+                                       *(msg + 16 * 1 + 10),
+                                       *(msg + 16 * 2 + 10),
+                                       *(msg + 16 * 3 + 10),
+                                       *(msg + 16 * 4 + 10),
+                                       *(msg + 16 * 5 + 10),
+                                       *(msg + 16 * 6 + 10),
+                                       *(msg + 16 * 7 + 10));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 11),
+                                       *(msg + 16 * 1 + 11),
+                                       *(msg + 16 * 2 + 11),
+                                       *(msg + 16 * 3 + 11),
+                                       *(msg + 16 * 4 + 11),
+                                       *(msg + 16 * 5 + 11),
+                                       *(msg + 16 * 6 + 11),
+                                       *(msg + 16 * 7 + 11));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 10),
-                                   *(msg + 16 * 1 + 10),
-                                   *(msg + 16 * 2 + 10),
-                                   *(msg + 16 * 3 + 10),
-                                   *(msg + 16 * 4 + 10),
-                                   *(msg + 16 * 5 + 10),
-                                   *(msg + 16 * 6 + 10),
-                                   *(msg + 16 * 7 + 10),
-                                   *(msg + 16 * 8 + 10),
-                                   *(msg + 16 * 9 + 10),
-                                   *(msg + 16 * 10 + 10),
-                                   *(msg + 16 * 11 + 10),
-                                   *(msg + 16 * 12 + 10),
-                                   *(msg + 16 * 13 + 10),
-                                   *(msg + 16 * 14 + 10),
-                                   *(msg + 16 * 15 + 10));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 11),
-                                   *(msg + 16 * 1 + 11),
-                                   *(msg + 16 * 2 + 11),
-                                   *(msg + 16 * 3 + 11),
-                                   *(msg + 16 * 4 + 11),
-                                   *(msg + 16 * 5 + 11),
-                                   *(msg + 16 * 6 + 11),
-                                   *(msg + 16 * 7 + 11),
-                                   *(msg + 16 * 8 + 11),
-                                   *(msg + 16 * 9 + 11),
-                                   *(msg + 16 * 10 + 11),
-                                   *(msg + 16 * 11 + 11),
-                                   *(msg + 16 * 12 + 11),
-                                   *(msg + 16 * 13 + 11),
-                                   *(msg + 16 * 14 + 11),
-                                   *(msg + 16 * 15 + 11));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 10),
+                                         *(msg + 16 * 1 + 10),
+                                         *(msg + 16 * 2 + 10),
+                                         *(msg + 16 * 3 + 10),
+                                         *(msg + 16 * 4 + 10),
+                                         *(msg + 16 * 5 + 10),
+                                         *(msg + 16 * 6 + 10),
+                                         *(msg + 16 * 7 + 10),
+                                         *(msg + 16 * 8 + 10),
+                                         *(msg + 16 * 9 + 10),
+                                         *(msg + 16 * 10 + 10),
+                                         *(msg + 16 * 11 + 10),
+                                         *(msg + 16 * 12 + 10),
+                                         *(msg + 16 * 13 + 10),
+                                         *(msg + 16 * 14 + 10),
+                                         *(msg + 16 * 15 + 10));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 11),
+                                         *(msg + 16 * 1 + 11),
+                                         *(msg + 16 * 2 + 11),
+                                         *(msg + 16 * 3 + 11),
+                                         *(msg + 16 * 4 + 11),
+                                         *(msg + 16 * 5 + 11),
+                                         *(msg + 16 * 6 + 11),
+                                         *(msg + 16 * 7 + 11),
+                                         *(msg + 16 * 8 + 11),
+                                         *(msg + 16 * 9 + 11),
+                                         *(msg + 16 * 10 + 11),
+                                         *(msg + 16 * 11 + 11),
+                                         *(msg + 16 * 12 + 11),
+                                         *(msg + 16 * 13 + 11),
+                                         *(msg + 16 * 14 + 11),
+                                         *(msg + 16 * 15 + 11));
 #endif
 
     blake3::v2::g(state, 1, 6, 11, 12, mx, my);
@@ -651,67 +663,69 @@ blake3::v2::round(
 
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 12), *(msg + 16 * 1 + 12));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 13), *(msg + 16 * 1 + 13));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 12), *(msg + 16 * 1 + 12));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 13), *(msg + 16 * 1 + 13));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 12),
-                                 *(msg + 16 * 1 + 12),
-                                 *(msg + 16 * 2 + 12),
-                                 *(msg + 16 * 3 + 12));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 13),
-                                 *(msg + 16 * 1 + 13),
-                                 *(msg + 16 * 2 + 13),
-                                 *(msg + 16 * 3 + 13));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 12),
+                                       *(msg + 16 * 1 + 12),
+                                       *(msg + 16 * 2 + 12),
+                                       *(msg + 16 * 3 + 12));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 13),
+                                       *(msg + 16 * 1 + 13),
+                                       *(msg + 16 * 2 + 13),
+                                       *(msg + 16 * 3 + 13));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 12),
-                                 *(msg + 16 * 1 + 12),
-                                 *(msg + 16 * 2 + 12),
-                                 *(msg + 16 * 3 + 12),
-                                 *(msg + 16 * 4 + 12),
-                                 *(msg + 16 * 5 + 12),
-                                 *(msg + 16 * 6 + 12),
-                                 *(msg + 16 * 7 + 12));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 13),
-                                 *(msg + 16 * 1 + 13),
-                                 *(msg + 16 * 2 + 13),
-                                 *(msg + 16 * 3 + 13),
-                                 *(msg + 16 * 4 + 13),
-                                 *(msg + 16 * 5 + 13),
-                                 *(msg + 16 * 6 + 13),
-                                 *(msg + 16 * 7 + 13));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 12),
+                                       *(msg + 16 * 1 + 12),
+                                       *(msg + 16 * 2 + 12),
+                                       *(msg + 16 * 3 + 12),
+                                       *(msg + 16 * 4 + 12),
+                                       *(msg + 16 * 5 + 12),
+                                       *(msg + 16 * 6 + 12),
+                                       *(msg + 16 * 7 + 12));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 13),
+                                       *(msg + 16 * 1 + 13),
+                                       *(msg + 16 * 2 + 13),
+                                       *(msg + 16 * 3 + 13),
+                                       *(msg + 16 * 4 + 13),
+                                       *(msg + 16 * 5 + 13),
+                                       *(msg + 16 * 6 + 13),
+                                       *(msg + 16 * 7 + 13));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 12),
-                                   *(msg + 16 * 1 + 12),
-                                   *(msg + 16 * 2 + 12),
-                                   *(msg + 16 * 3 + 12),
-                                   *(msg + 16 * 4 + 12),
-                                   *(msg + 16 * 5 + 12),
-                                   *(msg + 16 * 6 + 12),
-                                   *(msg + 16 * 7 + 12),
-                                   *(msg + 16 * 8 + 12),
-                                   *(msg + 16 * 9 + 12),
-                                   *(msg + 16 * 10 + 12),
-                                   *(msg + 16 * 11 + 12),
-                                   *(msg + 16 * 12 + 12),
-                                   *(msg + 16 * 13 + 12),
-                                   *(msg + 16 * 14 + 12),
-                                   *(msg + 16 * 15 + 12));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 13),
-                                   *(msg + 16 * 1 + 13),
-                                   *(msg + 16 * 2 + 13),
-                                   *(msg + 16 * 3 + 13),
-                                   *(msg + 16 * 4 + 13),
-                                   *(msg + 16 * 5 + 13),
-                                   *(msg + 16 * 6 + 13),
-                                   *(msg + 16 * 7 + 13),
-                                   *(msg + 16 * 8 + 13),
-                                   *(msg + 16 * 9 + 13),
-                                   *(msg + 16 * 10 + 13),
-                                   *(msg + 16 * 11 + 13),
-                                   *(msg + 16 * 12 + 13),
-                                   *(msg + 16 * 13 + 13),
-                                   *(msg + 16 * 14 + 13),
-                                   *(msg + 16 * 15 + 13));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 12),
+                                         *(msg + 16 * 1 + 12),
+                                         *(msg + 16 * 2 + 12),
+                                         *(msg + 16 * 3 + 12),
+                                         *(msg + 16 * 4 + 12),
+                                         *(msg + 16 * 5 + 12),
+                                         *(msg + 16 * 6 + 12),
+                                         *(msg + 16 * 7 + 12),
+                                         *(msg + 16 * 8 + 12),
+                                         *(msg + 16 * 9 + 12),
+                                         *(msg + 16 * 10 + 12),
+                                         *(msg + 16 * 11 + 12),
+                                         *(msg + 16 * 12 + 12),
+                                         *(msg + 16 * 13 + 12),
+                                         *(msg + 16 * 14 + 12),
+                                         *(msg + 16 * 15 + 12));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 13),
+                                         *(msg + 16 * 1 + 13),
+                                         *(msg + 16 * 2 + 13),
+                                         *(msg + 16 * 3 + 13),
+                                         *(msg + 16 * 4 + 13),
+                                         *(msg + 16 * 5 + 13),
+                                         *(msg + 16 * 6 + 13),
+                                         *(msg + 16 * 7 + 13),
+                                         *(msg + 16 * 8 + 13),
+                                         *(msg + 16 * 9 + 13),
+                                         *(msg + 16 * 10 + 13),
+                                         *(msg + 16 * 11 + 13),
+                                         *(msg + 16 * 12 + 13),
+                                         *(msg + 16 * 13 + 13),
+                                         *(msg + 16 * 14 + 13),
+                                         *(msg + 16 * 15 + 13));
 #endif
 
     blake3::v2::g(state, 2, 7, 8, 13, mx, my);
@@ -719,67 +733,69 @@ blake3::v2::round(
 
   {
 #if BLAKE3_SIMD_LANES == 2
-    sycl::uint2 mx = sycl::uint2(*(msg + 16 * 0 + 14), *(msg + 16 * 1 + 14));
-    sycl::uint2 my = sycl::uint2(*(msg + 16 * 0 + 15), *(msg + 16 * 1 + 15));
+    const sycl::uint2 mx =
+      sycl::uint2(*(msg + 16 * 0 + 14), *(msg + 16 * 1 + 14));
+    const sycl::uint2 my =
+      sycl::uint2(*(msg + 16 * 0 + 15), *(msg + 16 * 1 + 15));
 #elif BLAKE3_SIMD_LANES == 4
-    sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 14),
-                                 *(msg + 16 * 1 + 14),
-                                 *(msg + 16 * 2 + 14),
-                                 *(msg + 16 * 3 + 14));
-    sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 15),
-                                 *(msg + 16 * 1 + 15),
-                                 *(msg + 16 * 2 + 15),
-                                 *(msg + 16 * 3 + 15));
+    const sycl::uint4 mx = sycl::uint4(*(msg + 16 * 0 + 14),
+                                       *(msg + 16 * 1 + 14),
+                                       *(msg + 16 * 2 + 14),
+                                       *(msg + 16 * 3 + 14));
+    const sycl::uint4 my = sycl::uint4(*(msg + 16 * 0 + 15),
+                                       *(msg + 16 * 1 + 15),
+                                       *(msg + 16 * 2 + 15),
+                                       *(msg + 16 * 3 + 15));
 #elif BLAKE3_SIMD_LANES == 8
-    sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 14),
-                                 *(msg + 16 * 1 + 14),
-                                 *(msg + 16 * 2 + 14),
-                                 *(msg + 16 * 3 + 14),
-                                 *(msg + 16 * 4 + 14),
-                                 *(msg + 16 * 5 + 14),
-                                 *(msg + 16 * 6 + 14),
-                                 *(msg + 16 * 7 + 14));
-    sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 15),
-                                 *(msg + 16 * 1 + 15),
-                                 *(msg + 16 * 2 + 15),
-                                 *(msg + 16 * 3 + 15),
-                                 *(msg + 16 * 4 + 15),
-                                 *(msg + 16 * 5 + 15),
-                                 *(msg + 16 * 6 + 15),
-                                 *(msg + 16 * 7 + 15));
+    const sycl::uint8 mx = sycl::uint8(*(msg + 16 * 0 + 14),
+                                       *(msg + 16 * 1 + 14),
+                                       *(msg + 16 * 2 + 14),
+                                       *(msg + 16 * 3 + 14),
+                                       *(msg + 16 * 4 + 14),
+                                       *(msg + 16 * 5 + 14),
+                                       *(msg + 16 * 6 + 14),
+                                       *(msg + 16 * 7 + 14));
+    const sycl::uint8 my = sycl::uint8(*(msg + 16 * 0 + 15),
+                                       *(msg + 16 * 1 + 15),
+                                       *(msg + 16 * 2 + 15),
+                                       *(msg + 16 * 3 + 15),
+                                       *(msg + 16 * 4 + 15),
+                                       *(msg + 16 * 5 + 15),
+                                       *(msg + 16 * 6 + 15),
+                                       *(msg + 16 * 7 + 15));
 #elif BLAKE3_SIMD_LANES == 16
-    sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 14),
-                                   *(msg + 16 * 1 + 14),
-                                   *(msg + 16 * 2 + 14),
-                                   *(msg + 16 * 3 + 14),
-                                   *(msg + 16 * 4 + 14),
-                                   *(msg + 16 * 5 + 14),
-                                   *(msg + 16 * 6 + 14),
-                                   *(msg + 16 * 7 + 14),
-                                   *(msg + 16 * 8 + 14),
-                                   *(msg + 16 * 9 + 14),
-                                   *(msg + 16 * 10 + 14),
-                                   *(msg + 16 * 11 + 14),
-                                   *(msg + 16 * 12 + 14),
-                                   *(msg + 16 * 13 + 14),
-                                   *(msg + 16 * 14 + 14),
-                                   *(msg + 16 * 15 + 14));
-    sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 15),
-                                   *(msg + 16 * 1 + 15),
-                                   *(msg + 16 * 2 + 15),
-                                   *(msg + 16 * 3 + 15),
-                                   *(msg + 16 * 4 + 15),
-                                   *(msg + 16 * 5 + 15),
-                                   *(msg + 16 * 6 + 15),
-                                   *(msg + 16 * 7 + 15),
-                                   *(msg + 16 * 8 + 15),
-                                   *(msg + 16 * 9 + 15),
-                                   *(msg + 16 * 10 + 15),
-                                   *(msg + 16 * 11 + 15),
-                                   *(msg + 16 * 12 + 15),
-                                   *(msg + 16 * 13 + 15),
-                                   *(msg + 16 * 14 + 15),
-                                   *(msg + 16 * 15 + 15));
+    const sycl::uint16 mx = sycl::uint16(*(msg + 16 * 0 + 14),
+                                         *(msg + 16 * 1 + 14),
+                                         *(msg + 16 * 2 + 14),
+                                         *(msg + 16 * 3 + 14),
+                                         *(msg + 16 * 4 + 14),
+                                         *(msg + 16 * 5 + 14),
+                                         *(msg + 16 * 6 + 14),
+                                         *(msg + 16 * 7 + 14),
+                                         *(msg + 16 * 8 + 14),
+                                         *(msg + 16 * 9 + 14),
+                                         *(msg + 16 * 10 + 14),
+                                         *(msg + 16 * 11 + 14),
+                                         *(msg + 16 * 12 + 14),
+                                         *(msg + 16 * 13 + 14),
+                                         *(msg + 16 * 14 + 14),
+                                         *(msg + 16 * 15 + 14));
+    const sycl::uint16 my = sycl::uint16(*(msg + 16 * 0 + 15),
+                                         *(msg + 16 * 1 + 15),
+                                         *(msg + 16 * 2 + 15),
+                                         *(msg + 16 * 3 + 15),
+                                         *(msg + 16 * 4 + 15),
+                                         *(msg + 16 * 5 + 15),
+                                         *(msg + 16 * 6 + 15),
+                                         *(msg + 16 * 7 + 15),
+                                         *(msg + 16 * 8 + 15),
+                                         *(msg + 16 * 9 + 15),
+                                         *(msg + 16 * 10 + 15),
+                                         *(msg + 16 * 11 + 15),
+                                         *(msg + 16 * 12 + 15),
+                                         *(msg + 16 * 13 + 15),
+                                         *(msg + 16 * 14 + 15),
+                                         *(msg + 16 * 15 + 15));
 #endif
 
     blake3::v2::g(state, 3, 4, 9, 14, mx, my);
@@ -1136,7 +1152,7 @@ blake3::v2::compress(const sycl::uint* in_cv,
     // round i = {0, 1, ... 6}
     blake3::v2::round(state, block_words);
 
-    if (i < blake3::ROUNDS - 1) {
+    if (i < blake3::ROUNDS - 1) { // no need to permute after last round !
       for (size_t j = 0; j < BLAKE3_SIMD_LANES; j++) {
         blake3::permute(block_words + 16 * j);
       }
@@ -1145,6 +1161,8 @@ blake3::v2::compress(const sycl::uint* in_cv,
 
   // prepare output chaining values for 2/ 4/ 8/ 16 chunks
   // being compressed in parallel
+
+#pragma unroll 8 // this loop can be fully parallelized !
   for (size_t i = 0; i < 8; i++) {
     state[i] ^= state[i + 8];
   }
@@ -1152,184 +1170,184 @@ blake3::v2::compress(const sycl::uint* in_cv,
 #if BLAKE3_SIMD_LANES == 2
 // writing 32 -bytes output chaining value
 // for first chunk in this batch
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 0 + i) = state[i].x();
   }
 
 // output chaining value of last chunk in cluster
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 1 + i) = state[i].y();
   }
 #elif BLAKE3_SIMD_LANES == 4
 // writing 32 -bytes output chaining value
 // for first chunk in this batch
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 0 + i) = state[i].x();
   }
 
 // output chaining value of second chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 1 + i) = state[i].y();
   }
 
 // output chaining value of third chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 2 + i) = state[i].z();
   }
 
   // output chaining value of fourth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 3 + i) = state[i].w();
   }
 #elif BLAKE3_SIMD_LANES == 8
   // writing 32 -bytes output chaining value
   // for first chunk in this batch
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 0 + i) = state[i].s0();
   }
 
 // output chaining value of second chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 1 + i) = state[i].s1();
   }
 
   // output chaining value of third chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 2 + i) = state[i].s2();
   }
 
   // output chaining value of fourth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 3 + i) = state[i].s3();
   }
 
   // output chaining value of fifth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 4 + i) = state[i].s4();
   }
 
   // output chaining value of sixth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 5 + i) = state[i].s5();
   }
 
   // output chaining value of seventh chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 6 + i) = state[i].s6();
   }
 
   // output chaining value of eighth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 7 + i) = state[i].s7();
   }
 #elif BLAKE3_SIMD_LANES == 16
   // writing 32 -bytes output chaining value
   // for first chunk in this batch
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 0 + i) = state[i].s0();
   }
 
   // output chaining value of second chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 1 + i) = state[i].s1();
   }
 
   // output chaining value of third chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 2 + i) = state[i].s2();
   }
 
   // output chaining value of fourth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 3 + i) = state[i].s3();
   }
 
   // output chaining value of fifth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 4 + i) = state[i].s4();
   }
 
   // output chaining value of sixth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 5 + i) = state[i].s5();
   }
 
   // output chaining value of seventh chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 6 + i) = state[i].s6();
   }
 
   // output chaining value of eighth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 7 + i) = state[i].s7();
   }
 
   // output chaining value of ninth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 8 + i) = state[i].s8();
   }
 
   // output chaining value of tenth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 9 + i) = state[i].s9();
   }
 
   // output chaining value of eleventh chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 10 + i) = state[i].sA();
   }
 
   // output chaining value of twelveth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 11 + i) = state[i].sB();
   }
 
   // output chaining value of thirteenth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 12 + i) = state[i].sC();
   }
 
   // output chaining value of fourteenth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 13 + i) = state[i].sD();
   }
 
   // output chaining value of fifteenth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 14 + i) = state[i].sE();
   }
 
 // output chaining value of sixteenth chunk
-#pragma unroll
+#pragma unroll 8
   for (size_t i = 0; i < 8; i++) {
     *(out_cv + 8 * 15 + i) = state[i].sF();
   }
@@ -1344,27 +1362,28 @@ blake3::v2::chunkify(const sycl::uint* key_words,
                      sycl::uint* const out_cv)
 {
 #if BLAKE3_SIMD_LANES == 2
-  sycl::uint in_cv[16] = { 0 };
-  sycl::uint priv_out_cv[16] = { 0 };
-  sycl::uint block_words[32] = { 0 };
+  sycl::uint in_cv[16];
+  sycl::uint priv_out_cv[16];
+  sycl::uint block_words[32];
 #elif BLAKE3_SIMD_LANES == 4
-  sycl::uint in_cv[32] = { 0 };
-  sycl::uint priv_out_cv[32] = { 0 };
-  sycl::uint block_words[64] = { 0 };
+  sycl::uint in_cv[32];
+  sycl::uint priv_out_cv[32];
+  sycl::uint block_words[64];
 #elif BLAKE3_SIMD_LANES == 8
-  sycl::uint in_cv[64] = { 0 };
-  sycl::uint priv_out_cv[64] = { 0 };
-  sycl::uint block_words[128] = { 0 };
+  sycl::uint in_cv[64];
+  sycl::uint priv_out_cv[64];
+  sycl::uint block_words[128];
 #elif BLAKE3_SIMD_LANES == 16
-  sycl::uint in_cv[128] = { 0 };
-  sycl::uint priv_out_cv[128] = { 0 };
-  sycl::uint block_words[256] = { 0 };
+  sycl::uint in_cv[128];
+  sycl::uint priv_out_cv[128];
+  sycl::uint block_words[256];
 #endif
 
+#pragma unroll // letting compiler decide, if something can be done about it
   for (size_t i = 0; i < 8; i++) {
     sycl::uint tmp = *(key_words + i);
 
-#pragma unroll
+#pragma unroll BLAKE3_SIMD_LANES // can be fully parallelized
     for (size_t j = 0; j < BLAKE3_SIMD_LANES; j++) {
       in_cv[i + 8 * j] = tmp;
     }
@@ -1408,7 +1427,7 @@ blake3::v2::chunkify(const sycl::uint* key_words,
     }
 
     if (i < 15) {
-#pragma unroll
+#pragma unroll 8 // attempt partial unrolling !
       for (size_t j = 0; j < 8 * BLAKE3_SIMD_LANES; j++) {
         in_cv[j] = priv_out_cv[j];
       }
@@ -1625,10 +1644,14 @@ blake3::permute(sycl::uint* const msg)
 {
   sycl::uint permuted[16] = { 0 };
 
+  // following two loops can be parallelized by fully unrolling !
+
+#pragma unroll 16 // fully unroll this loop
   for (size_t i = 0; i < 16; i++) {
     permuted[i] = *(msg + blake3::MSG_PERMUTATION[i]);
   }
 
+#pragma unroll 16 // fully unroll this loop
   for (size_t i = 0; i < 16; i++) {
     *(msg + i) = permuted[i];
   }

--- a/include/blake3.hpp
+++ b/include/blake3.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #define SYCL_SIMPLE_SWIZZLES 1
+#include "blake3_consts.hpp"
+#include "utils.hpp"
 #include <CL/sycl.hpp>
 #include <cassert>
 
@@ -23,23 +25,6 @@
 #pragma message PREP_MSG(BLAKE3_SIMD_LANES)
 
 namespace blake3 {
-constexpr size_t MSG_PERMUTATION[16] = { 2, 6,  3,  10, 7, 0,  4,  13,
-                                         1, 11, 12, 5,  9, 14, 15, 8 };
-
-constexpr sycl::uint IV[8] = { 0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
-                               0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19 };
-
-constexpr size_t CHUNK_LEN = 1024;
-constexpr size_t OUT_LEN = 32;
-
-constexpr size_t ROUNDS = 7;
-
-constexpr sycl::uint BLOCK_LEN = 64;
-constexpr sycl::uint CHUNK_START = 1 << 0;
-constexpr sycl::uint CHUNK_END = 1 << 1;
-constexpr sycl::uint PARENT = 1 << 2;
-constexpr sycl::uint ROOT = 1 << 3;
-
 void
 permute(sycl::uint* const msg);
 

--- a/include/blake3_consts.hpp
+++ b/include/blake3_consts.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <CL/sycl.hpp>
+
+namespace blake3 {
+constexpr size_t MSG_PERMUTATION[16] = { 2, 6,  3,  10, 7, 0,  4,  13,
+                                         1, 11, 12, 5,  9, 14, 15, 8 };
+
+constexpr sycl::uint IV[8] = { 0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+                               0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19 };
+
+constexpr size_t CHUNK_LEN = 1024;
+constexpr size_t OUT_LEN = 32;
+
+constexpr size_t ROUNDS = 7;
+
+constexpr sycl::uint BLOCK_LEN = 64;
+constexpr sycl::uint CHUNK_START = 1 << 0;
+constexpr sycl::uint CHUNK_END = 1 << 1;
+constexpr sycl::uint PARENT = 1 << 2;
+constexpr sycl::uint ROOT = 1 << 3;
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -11,3 +11,18 @@ prepare_blake3_input(size_t chunk_count, sycl::uchar* const in)
     }
   }
 }
+
+// Ensure that SYCL queue has profiling enabled !
+//
+// Returns actual execution time of command, submission of which
+// resulted into this SYCL event
+inline sycl::cl_ulong
+time_event(sycl::event& evt)
+{
+  const sycl::cl_ulong start =
+    evt.get_profiling_info<sycl::info::event_profiling::command_start>();
+  const sycl::cl_ulong end =
+    evt.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+  return (end - start);
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "blake3.hpp"
+#include "blake3_consts.hpp"
 #include <CL/sycl.hpp>
 
 void

--- a/results/intel_cpu.md
+++ b/results/intel_cpu.md
@@ -12,90 +12,90 @@ running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
 
 Benchmarking BLAKE3 SYCL implementation (v1)
 
-              input size                  execution time
-                   1 MB                    1.535053 ms
-                   2 MB                    2.324566 ms
-                   4 MB                    4.421891 ms
-                   8 MB                    8.682190 ms
-                  16 MB                   17.326016 ms
-                  32 MB                   34.776514 ms
-                  64 MB                   68.288191 ms
-                 128 MB                  141.008220 ms
-                 256 MB                  271.600802 ms
-                 512 MB                  541.594876 ms
-                1024 MB                     1.086021 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.411340 ms                   302.379750 us                     3.128375 us
+                   2 MB                    2.382188 ms                   502.974125 us                     2.244875 us
+                   4 MB                    4.551627 ms                   978.917750 us                     1.813500 us
+                   8 MB                    8.884377 ms                     1.928709 ms                     2.123000 us
+                  16 MB                   17.718145 ms                     4.421330 ms                     2.502000 us
+                  32 MB                   35.164200 ms                     8.941067 ms                     3.316250 us
+                  64 MB                   73.808522 ms                    18.136102 ms                     2.870250 us
+                 128 MB                  149.423070 ms                    37.800974 ms                     3.243750 us
+                 256 MB                  278.700030 ms                    73.604903 ms                     2.825250 us
+                 512 MB                  556.898126 ms                   148.596441 ms                     2.950250 us
+                1024 MB                     1.126861 s                   293.848222 ms                     3.435000 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=2
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    2.640065 ms
-                   2 MB                    4.589143 ms
-                   4 MB                    8.974861 ms
-                   8 MB                   17.664158 ms
-                  16 MB                   35.176459 ms
-                  32 MB                   70.473792 ms
-                  64 MB                  140.738687 ms
-                 128 MB                  280.730679 ms
-                 256 MB                  558.651098 ms
-                 512 MB                     1.119648 s
-                1024 MB                     2.231913 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    2.458254 ms                   290.517125 us                     2.240000 us
+                   2 MB                    4.403440 ms                   516.484625 us                     2.325625 us
+                   4 MB                    8.571496 ms                     1.013186 ms                     2.281625 us
+                   8 MB                   17.256722 ms                     2.134683 ms                     2.414000 us
+                  16 MB                   33.931112 ms                     4.449573 ms                     2.584750 us
+                  32 MB                   67.583474 ms                     9.160075 ms                     3.510875 us
+                  64 MB                  134.817304 ms                    17.928418 ms                     3.086500 us
+                 128 MB                  269.274363 ms                    35.857533 ms                     3.475250 us
+                 256 MB                  536.382903 ms                    74.012070 ms                     2.823750 us
+                 512 MB                     1.107967 s                   149.691718 ms                     3.079375 us
+                1024 MB                     2.264229 s                   300.741099 ms                     2.879375 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=4
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    2.410590 ms
-                   2 MB                    4.483136 ms
-                   4 MB                    9.490823 ms
-                   8 MB                   17.348939 ms
-                  16 MB                   27.069447 ms
-                  32 MB                   53.444846 ms
-                  64 MB                  107.797906 ms
-                 128 MB                  211.315984 ms
-                 256 MB                  421.151311 ms
-                 512 MB                  851.662736 ms
-                1024 MB                     1.704885 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.457193 ms                   297.706000 us                     2.182750 us
+                   2 MB                    2.597208 ms                   535.761625 us                     2.190375 us
+                   4 MB                    4.948043 ms                   984.825125 us                     1.835000 us
+                   8 MB                    9.656003 ms                     1.903438 ms                     2.037875 us
+                  16 MB                   19.059954 ms                     4.102028 ms                     2.157000 us
+                  32 MB                   37.820617 ms                     9.093352 ms                     2.961375 us
+                  64 MB                   75.408616 ms                    17.937515 ms                     2.687875 us
+                 128 MB                  150.304798 ms                    35.845284 ms                     2.909750 us
+                 256 MB                  299.651055 ms                    74.402049 ms                     2.493250 us
+                 512 MB                  599.306090 ms                   148.221302 ms                     2.565250 us
+                1024 MB                     1.214943 s                   299.679108 ms                     3.162625 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=8
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    3.255826 ms
-                   2 MB                    5.385626 ms
-                   4 MB                   10.517980 ms
-                   8 MB                   20.980429 ms
-                  16 MB                   41.627366 ms
-                  32 MB                   81.449933 ms
-                  64 MB                  164.480672 ms
-                 128 MB                  321.240538 ms
-                 256 MB                  644.155882 ms
-                 512 MB                     1.280831 s
-                1024 MB                     2.557385 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.454525 ms                   300.303500 us                     2.049000 us
+                   2 MB                    2.490826 ms                   532.865750 us                     2.462125 us
+                   4 MB                    4.858460 ms                     1.058994 ms                     2.142125 us
+                   8 MB                    9.548375 ms                     2.168333 ms                     2.666750 us
+                  16 MB                   18.724246 ms                     4.372800 ms                     2.873750 us
+                  32 MB                   36.474041 ms                     9.020951 ms                     2.978500 us
+                  64 MB                   72.999172 ms                    17.845079 ms                     2.894000 us
+                 128 MB                  145.707888 ms                    36.177141 ms                     2.912500 us
+                 256 MB                  296.205519 ms                    75.066909 ms                     2.762125 us
+                 512 MB                  578.887824 ms                   145.805123 ms                     2.769000 us
+                1024 MB                     1.153393 s                   289.286738 ms                     2.724625 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=16
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    9.663129 ms
-                   2 MB                   12.756929 ms
-                   4 MB                   25.793409 ms
-                   8 MB                   50.483286 ms
-                  16 MB                  102.267502 ms
-                  32 MB                  202.261208 ms
-                  64 MB                  395.185795 ms
-                 128 MB                  791.928735 ms
-                 256 MB                     1.572042 s
-                 512 MB                     3.143899 s
-                1024 MB                     6.256395 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    5.484708 ms                   293.350750 us                     1.923000 us
+                   2 MB                    7.038828 ms                   526.952375 us                     2.219125 us
+                   4 MB                   14.028125 ms                     1.044917 ms                     2.349875 us
+                   8 MB                   28.113723 ms                     2.153057 ms                     2.522125 us
+                  16 MB                   55.646375 ms                     4.334506 ms                     2.868500 us
+                  32 MB                  107.368298 ms                     9.117504 ms                     3.173625 us
+                  64 MB                  211.528465 ms                    18.809700 ms                     2.976500 us
+                 128 MB                  422.311642 ms                    35.872375 ms                     3.016750 us
+                 256 MB                  839.858409 ms                    73.837866 ms                     2.992875 us
+                 512 MB                     1.679492 s                   147.312903 ms                     2.831250 us
+                1024 MB                     3.354590 s                   294.967816 ms                     2.814375 us
 ```
 
 ---
@@ -108,90 +108,90 @@ running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
 
 Benchmarking BLAKE3 SYCL implementation (v1)
 
-              input size                  execution time
-                   1 MB                    1.120702 ms
-                   2 MB                    1.202172 ms
-                   4 MB                    1.410422 ms
-                   8 MB                    2.018987 ms
-                  16 MB                    2.500873 ms
-                  32 MB                    4.527778 ms
-                  64 MB                    6.451395 ms
-                 128 MB                    8.719392 ms
-                 256 MB                    9.835248 ms
-                 512 MB                   13.150252 ms
-                1024 MB                   22.911430 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.035622 ms                   941.733125 us                    12.349500 us
+                   2 MB                  949.878750 us                     1.528471 ms                     8.627375 us
+                   4 MB                    1.224290 ms                     1.763114 ms                     5.351500 us
+                   8 MB                    1.713689 ms                     2.125699 ms                     5.597750 us
+                  16 MB                    2.568303 ms                     3.061066 ms                     5.793125 us
+                  32 MB                    4.168138 ms                     5.230914 ms                     6.145125 us
+                  64 MB                    6.239875 ms                     9.797500 ms                     2.525625 us
+                 128 MB                    8.187520 ms                    20.664062 ms                     1.242000 us
+                 256 MB                    8.853032 ms                    32.455801 ms                     1.047125 us
+                 512 MB                   14.807205 ms                    48.242437 ms                     1.063000 us
+                1024 MB                   22.864140 ms                    79.047688 ms                     1.088500 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=2
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    1.428717 ms
-                   2 MB                    1.642099 ms
-                   4 MB                    1.635514 ms
-                   8 MB                    1.794220 ms
-                  16 MB                    2.877134 ms
-                  32 MB                    4.975101 ms
-                  64 MB                    7.723535 ms
-                 128 MB                    9.583591 ms
-                 256 MB                   11.267384 ms
-                 512 MB                   19.438637 ms
-                1024 MB                   36.229899 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.435731 ms                   829.346250 us                     2.538125 us
+                   2 MB                    1.235621 ms                     1.160755 ms                     4.529125 us
+                   4 MB                    1.467002 ms                     1.388256 ms                     4.071250 us
+                   8 MB                    1.676693 ms                     1.940926 ms                     5.912250 us
+                  16 MB                    2.752172 ms                     3.576378 ms                     3.839875 us
+                  32 MB                    4.738109 ms                     6.948434 ms                     4.638500 us
+                  64 MB                    7.193866 ms                    13.689200 ms                     4.531500 us
+                 128 MB                    8.897695 ms                    23.638901 ms                   987.625000 ns
+                 256 MB                   10.928828 ms                    33.915237 ms                   967.625000 ns
+                 512 MB                   18.045038 ms                    48.268317 ms                     1.031375 us
+                1024 MB                   35.084335 ms                    76.414034 ms                   903.625000 ns
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=4
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    1.917579 ms
-                   2 MB                    2.283876 ms
-                   4 MB                    2.204972 ms
-                   8 MB                    2.605916 ms
-                  16 MB                    2.589251 ms
-                  32 MB                    4.494377 ms
-                  64 MB                    6.678979 ms
-                 128 MB                    8.999207 ms
-                 256 MB                   10.714447 ms
-                 512 MB                   23.924218 ms
-                1024 MB                   30.603181 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.332648 ms                   778.364750 us                     4.491625 us
+                   2 MB                    1.517697 ms                     1.216136 ms                     5.699500 us
+                   4 MB                    1.878738 ms                     1.405623 ms                     6.585000 us
+                   8 MB                    1.955160 ms                     1.890794 ms                     6.283625 us
+                  16 MB                    2.295545 ms                     3.461322 ms                     4.179250 us
+                  32 MB                    3.848329 ms                     6.653417 ms                     4.561875 us
+                  64 MB                    6.739462 ms                    14.008103 ms                     2.967625 us
+                 128 MB                    7.512532 ms                    21.777197 ms                   857.000000 ns
+                 256 MB                    8.854166 ms                    32.901272 ms                   976.500000 ns
+                 512 MB                   13.710111 ms                    47.194467 ms                   965.875000 ns
+                1024 MB                   25.805447 ms                    79.800968 ms                     1.052625 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=8
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    5.885517 ms
-                   2 MB                    4.910260 ms
-                   4 MB                    6.543840 ms
-                   8 MB                    6.718442 ms
-                  16 MB                    7.986787 ms
-                  32 MB                    7.846674 ms
-                  64 MB                   11.835337 ms
-                 128 MB                   15.333313 ms
-                 256 MB                   20.527009 ms
-                 512 MB                   34.983701 ms
-                1024 MB                   66.248736 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.957192 ms                   715.214875 us                     5.877000 us
+                   2 MB                    1.925397 ms                     1.117507 ms                     3.798000 us
+                   4 MB                    3.097539 ms                     1.451939 ms                    13.072625 us
+                   8 MB                    3.446283 ms                     1.918505 ms                     6.290750 us
+                  16 MB                    3.690009 ms                     3.503353 ms                     6.937875 us
+                  32 MB                    4.282732 ms                     6.779036 ms                     5.052125 us
+                  64 MB                    7.261953 ms                    14.829467 ms                     2.978000 us
+                 128 MB                    9.568175 ms                    22.821287 ms                   878.000000 ns
+                 256 MB                   10.290331 ms                    33.643110 ms                     1.030125 us
+                 512 MB                   15.784226 ms                    47.931818 ms                   863.375000 ns
+                1024 MB                   28.765474 ms                    80.076494 ms                     1.017875 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=16
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                   10.410064 ms
-                   2 MB                   10.397995 ms
-                   4 MB                   10.909045 ms
-                   8 MB                   16.981154 ms
-                  16 MB                   17.341112 ms
-                  32 MB                   17.184630 ms
-                  64 MB                   14.893981 ms
-                 128 MB                   18.590236 ms
-                 256 MB                   25.271265 ms
-                 512 MB                   49.042535 ms
-                1024 MB                   91.502870 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    6.539631 ms                   949.643375 us                     6.476625 us
+                   2 MB                    7.431457 ms                     1.504223 ms                     6.843000 us
+                   4 MB                    7.110438 ms                     1.818267 ms                     5.692250 us
+                   8 MB                   10.708573 ms                     3.247708 ms                     5.178500 us
+                  16 MB                   13.190738 ms                     3.451771 ms                     3.659125 us
+                  32 MB                   13.757709 ms                     5.561875 ms                     3.393625 us
+                  64 MB                   11.546031 ms                    13.229008 ms                     1.385125 us
+                 128 MB                   14.950347 ms                    22.513792 ms                     1.014875 us
+                 256 MB                   18.790299 ms                    33.722702 ms                   966.125000 ns
+                 512 MB                   33.867609 ms                    47.791360 ms                     1.216500 us
+                1024 MB                   61.698307 ms                    75.633475 ms                     1.107500 us
 ```
 ---
 
@@ -203,90 +203,90 @@ running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
 
 Benchmarking BLAKE3 SYCL implementation (v1)
 
-              input size                  execution time
-                   1 MB                  487.521000 us
-                   2 MB                  762.363000 us
-                   4 MB                    1.586235 ms
-                   8 MB                    1.867494 ms
-                  16 MB                    4.839855 ms
-                  32 MB                    6.741284 ms
-                  64 MB                   11.746437 ms
-                 128 MB                   15.007609 ms
-                 256 MB                   22.384890 ms
-                 512 MB                   42.334697 ms
-                1024 MB                   84.325357 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  357.017500 us                   308.464000 us                     1.038625 us
+                   2 MB                  536.530125 us                   551.713750 us                     2.091125 us
+                   4 MB                    1.139873 ms                   811.976750 us                     2.913250 us
+                   8 MB                    1.910413 ms                     1.322750 ms                     2.355250 us
+                  16 MB                    3.611798 ms                     2.494118 ms                   971.125000 ns
+                  32 MB                    6.082726 ms                     4.624181 ms                   921.625000 ns
+                  64 MB                   10.105840 ms                     8.526520 ms                   897.000000 ns
+                 128 MB                   14.036209 ms                    15.155051 ms                     1.050000 us
+                 256 MB                   20.757668 ms                    27.175328 ms                     1.198875 us
+                 512 MB                   39.001923 ms                    44.536675 ms                     1.223750 us
+                1024 MB                   77.331343 ms                    91.330096 ms                     1.203125 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=2
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                  853.001000 us
-                   2 MB                    1.210407 ms
-                   4 MB                    1.973600 ms
-                   8 MB                    3.354756 ms
-                  16 MB                    6.106087 ms
-                  32 MB                   12.527090 ms
-                  64 MB                   15.471883 ms
-                 128 MB                   21.568805 ms
-                 256 MB                   35.273785 ms
-                 512 MB                   68.225128 ms
-                1024 MB                  135.332831 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  725.956250 us                   321.646625 us                     1.812625 us
+                   2 MB                    1.063598 ms                   574.803250 us                     2.297000 us
+                   4 MB                    1.853857 ms                   811.289625 us                     2.623625 us
+                   8 MB                    3.265703 ms                     1.355988 ms                     1.887375 us
+                  16 MB                    5.695174 ms                     2.375724 ms                   669.875000 ns
+                  32 MB                   10.207269 ms                     5.329347 ms                   849.000000 ns
+                  64 MB                   14.268392 ms                     7.847511 ms                   967.375000 ns
+                 128 MB                   20.377278 ms                    14.777122 ms                     1.126875 us
+                 256 MB                   33.007169 ms                    25.580627 ms                     1.522875 us
+                 512 MB                   62.540990 ms                    47.311655 ms                     1.087875 us
+                1024 MB                  124.047302 ms                    83.641604 ms                     1.418875 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=4
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    1.243179 ms
-                   2 MB                    1.280228 ms
-                   4 MB                    2.007901 ms
-                   8 MB                    3.308409 ms
-                  16 MB                    5.598625 ms
-                  32 MB                    9.700557 ms
-                  64 MB                   13.496357 ms
-                 128 MB                   18.964755 ms
-                 256 MB                   29.735171 ms
-                 512 MB                   56.552652 ms
-                1024 MB                  112.375748 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  850.803500 us                   240.196625 us                     1.433625 us
+                   2 MB                    1.028460 ms                   613.574500 us                     2.795375 us
+                   4 MB                    1.686378 ms                   819.039000 us                     2.232500 us
+                   8 MB                    2.583981 ms                     1.327759 ms                     1.756625 us
+                  16 MB                    4.535992 ms                     2.399812 ms                   739.750000 ns
+                  32 MB                    7.715149 ms                     4.566527 ms                   868.625000 ns
+                  64 MB                   12.397610 ms                     8.777051 ms                   987.500000 ns
+                 128 MB                   16.035606 ms                    15.090863 ms                     1.112125 us
+                 256 MB                   23.686623 ms                    28.505377 ms                     1.196625 us
+                 512 MB                   44.435378 ms                    44.838008 ms                     1.637875 us
+                1024 MB                   87.095254 ms                    86.813492 ms                     1.280750 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=8
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    3.402214 ms
-                   2 MB                    3.643949 ms
-                   4 MB                    4.609026 ms
-                   8 MB                    8.684951 ms
-                  16 MB                   13.997617 ms
-                  32 MB                   17.660809 ms
-                  64 MB                   24.978581 ms
-                 128 MB                   36.671089 ms
-                 256 MB                   63.932004 ms
-                 512 MB                  122.961880 ms
-                1024 MB                  249.416206 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.434828 ms                   341.291500 us                     2.925000 us
+                   2 MB                    2.028067 ms                   691.156625 us                     2.299750 us
+                   4 MB                    2.169944 ms                   841.397000 us                     2.468625 us
+                   8 MB                    3.577898 ms                     1.354724 ms                     2.677625 us
+                  16 MB                    5.726758 ms                     2.392596 ms                   585.125000 ns
+                  32 MB                    9.302333 ms                     4.546784 ms                   669.750000 ns
+                  64 MB                   14.719235 ms                     8.442529 ms                     1.213750 us
+                 128 MB                   17.816075 ms                    14.553390 ms                   897.250000 ns
+                 256 MB                   27.092123 ms                    25.995475 ms                     1.458500 us
+                 512 MB                   51.581485 ms                    48.473726 ms                     1.213000 us
+                1024 MB                  101.127829 ms                    85.415163 ms                   981.500000 ns
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=16
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    7.460626 ms
-                   2 MB                    7.486521 ms
-                   4 MB                   11.438846 ms
-                   8 MB                   13.760393 ms
-                  16 MB                   17.528906 ms
-                  32 MB                   24.643870 ms
-                  64 MB                   34.102165 ms
-                 128 MB                   53.097703 ms
-                 256 MB                  108.135065 ms
-                 512 MB                  184.124070 ms
-                1024 MB                  369.643404 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    4.988956 ms                   345.659875 us                     2.517500 us
+                   2 MB                    6.923827 ms                   721.461250 us                     1.908625 us
+                   4 MB                    8.343197 ms                     1.045322 ms                     1.605875 us
+                   8 MB                    9.554885 ms                     1.576714 ms                   928.750000 ns
+                  16 MB                   14.489025 ms                     2.544420 ms                   813.875000 ns
+                  32 MB                   17.014290 ms                     4.073476 ms                     1.041375 us
+                  64 MB                   25.710434 ms                     7.544063 ms                     1.052000 us
+                 128 MB                   36.536837 ms                    16.001267 ms                     1.483125 us
+                 256 MB                   63.283484 ms                    26.332025 ms                     1.233125 us
+                 512 MB                  121.902091 ms                    45.809442 ms                     1.067750 us
+                1024 MB                  245.176609 ms                    83.243050 ms                     1.076375 us
 ```
 
 ---
@@ -299,88 +299,184 @@ running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
 
 Benchmarking BLAKE3 SYCL implementation (v1)
 
-              input size                  execution time
-                   1 MB                  564.571000 us
-                   2 MB                  936.153000 us
-                   4 MB                    1.410566 ms
-                   8 MB                    2.505761 ms
-                  16 MB                    4.465773 ms
-                  32 MB                    8.561860 ms
-                  64 MB                   17.522937 ms
-                 128 MB                   31.613256 ms
-                 256 MB                   62.566890 ms
-                 512 MB                  124.029188 ms
-                1024 MB                  250.726431 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  327.447125 us                   164.797750 us                     3.334250 us
+                   2 MB                  888.252500 us                   208.945000 us                   600.375000 ns
+                   4 MB                    1.049447 ms                   297.244750 us                     2.543375 us
+                   8 MB                    2.007394 ms                   561.511250 us                     2.600250 us
+                  16 MB                    3.868704 ms                     1.221595 ms                   820.250000 ns
+                  32 MB                    7.259625 ms                     2.429787 ms                   677.000000 ns
+                  64 MB                   13.978607 ms                     4.754956 ms                   736.250000 ns
+                 128 MB                   27.780513 ms                     9.330577 ms                   749.500000 ns
+                 256 MB                   55.302504 ms                    18.498851 ms                   875.750000 ns
+                 512 MB                  110.761080 ms                    36.818487 ms                   809.000000 ns
+                1024 MB                  220.764015 ms                    73.411591 ms                   849.000000 ns
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=2
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                  868.955000 us
-                   2 MB                    1.116056 ms
-                   4 MB                    1.941763 ms
-                   8 MB                    3.510570 ms
-                  16 MB                    6.327400 ms
-                  32 MB                   11.889369 ms
-                  64 MB                   23.159883 ms
-                 128 MB                   45.566010 ms
-                 256 MB                   90.169047 ms
-                 512 MB                  187.951293 ms
-                1024 MB                  358.965746 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  551.211125 us                   148.376625 us                   616.875000 ns
+                   2 MB                  796.079000 us                   196.313375 us                   505.250000 ns
+                   4 MB                    1.401199 ms                   286.559000 us                   705.500000 ns
+                   8 MB                    2.544254 ms                   535.589000 us                   550.000000 ns
+                  16 MB                    4.819938 ms                     1.201561 ms                   566.750000 ns
+                  32 MB                    9.369013 ms                     2.404684 ms                   592.625000 ns
+                  64 MB                   18.504175 ms                     4.758154 ms                   673.000000 ns
+                 128 MB                   36.716331 ms                     9.319614 ms                   613.750000 ns
+                 256 MB                   73.104492 ms                    18.491373 ms                     2.659625 us
+                 512 MB                  145.770998 ms                    36.832426 ms                   780.250000 ns
+                1024 MB                  291.536176 ms                    73.392269 ms                   795.375000 ns
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=4
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                  887.412000 us
-                   2 MB                    1.355160 ms
-                   4 MB                    1.966733 ms
-                   8 MB                    3.624923 ms
-                  16 MB                    6.220828 ms
-                  32 MB                   11.620348 ms
-                  64 MB                   22.279148 ms
-                 128 MB                   43.852904 ms
-                 256 MB                   86.801124 ms
-                 512 MB                  172.498208 ms
-                1024 MB                  347.183344 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  477.501875 us                   128.105000 us                   617.250000 ns
+                   2 MB                  819.885750 us                   212.460875 us                     2.089375 us
+                   4 MB                    1.207255 ms                   312.599375 us                   488.250000 ns
+                   8 MB                    2.296374 ms                   603.953250 us                   690.875000 ns
+                  16 MB                    4.145224 ms                     1.188992 ms                   784.875000 ns
+                  32 MB                    7.876318 ms                     2.414666 ms                   616.250000 ns
+                  64 MB                   15.409500 ms                     4.763488 ms                   733.750000 ns
+                 128 MB                   30.456902 ms                     9.318929 ms                   903.000000 ns
+                 256 MB                   60.333662 ms                    18.490137 ms                   786.500000 ns
+                 512 MB                  125.270049 ms                    36.855571 ms                     2.960625 us
+                1024 MB                  246.221199 ms                    73.462219 ms                   746.875000 ns
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=8
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    1.570597 ms
-                   2 MB                    1.850503 ms
-                   4 MB                    3.342631 ms
-                   8 MB                    4.997062 ms
-                  16 MB                    9.387379 ms
-                  32 MB                   17.081930 ms
-                  64 MB                   32.851853 ms
-                 128 MB                   64.640995 ms
-                 256 MB                  127.836171 ms
-                 512 MB                  254.326319 ms
-                1024 MB                  510.912368 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  734.042875 us                   149.736375 us                   808.000000 ns
+                   2 MB                  805.438250 us                   218.295750 us                     2.174000 us
+                   4 MB                    1.437623 ms                   316.812250 us                   623.375000 ns
+                   8 MB                    2.154406 ms                   545.291375 us                   578.750000 ns
+                  16 MB                    3.991284 ms                     1.201524 ms                   794.500000 ns
+                  32 MB                    7.543487 ms                     2.410248 ms                   702.125000 ns
+                  64 MB                   14.637162 ms                     4.762942 ms                   654.750000 ns
+                 128 MB                   28.733478 ms                     9.324469 ms                   756.750000 ns
+                 256 MB                   56.476447 ms                    18.507013 ms                   754.375000 ns
+                 512 MB                  114.561923 ms                    36.832606 ms                   812.875000 ns
+                1024 MB                  223.173748 ms                    73.414237 ms                   805.375000 ns
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=16
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    3.490090 ms
-                   2 MB                    4.617491 ms
-                   4 MB                    6.602516 ms
-                   8 MB                   12.637082 ms
-                  16 MB                   19.329369 ms
-                  32 MB                   37.111232 ms
-                  64 MB                   70.162086 ms
-                 128 MB                  135.925034 ms
-                 256 MB                  269.854776 ms
-                 512 MB                  531.697001 ms
-                1024 MB                     1.062264 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.953116 ms                   153.074750 us                   695.500000 ns
+                   2 MB                    2.619823 ms                   220.599125 us                   450.875000 ns
+                   4 MB                    3.475796 ms                   307.221125 us                   566.375000 ns
+                   8 MB                    6.571765 ms                   538.039000 us                   624.750000 ns
+                  16 MB                   10.114083 ms                     1.205012 ms                   623.750000 ns
+                  32 MB                   19.093997 ms                     2.413813 ms                   670.625000 ns
+                  64 MB                   36.166322 ms                     4.747795 ms                   622.375000 ns
+                 128 MB                   70.424445 ms                     9.322505 ms                   771.875000 ns
+                 256 MB                  146.945313 ms                    18.511632 ms                   726.625000 ns
+                 512 MB                  277.160686 ms                    36.837060 ms                   696.500000 ns
+                1024 MB                  555.891941 ms                    73.445136 ms                   647.875000 ns
+```
+
+---
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+# [ CPU(s): 24; used avx512 ]
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+Benchmarking BLAKE3 SYCL implementation (v1)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  287.689500 us                   189.727375 us                   614.875000 ns
+                   2 MB                  406.320375 us                   260.700125 us                     1.006625 us
+                   4 MB                  955.492625 us                   528.503750 us                     1.154000 us
+                   8 MB                    1.851749 ms                     1.076688 ms                     1.454250 us
+                  16 MB                    3.337930 ms                     2.010356 ms                     1.128250 us
+                  32 MB                    6.305565 ms                     3.795659 ms                   739.250000 ns
+                  64 MB                   10.437824 ms                     6.534568 ms                   901.375000 ns
+                 128 MB                   12.251488 ms                    11.281635 ms                     1.639750 us
+                 256 MB                   20.167881 ms                    21.406765 ms                     3.363500 us
+                 512 MB                   38.131119 ms                    42.965097 ms                     2.042500 us
+                1024 MB                   75.931118 ms                    83.779978 ms                     1.040875 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=2
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  524.511750 us                   207.601500 us                     1.250125 us
+                   2 MB                  759.372875 us                   281.304875 us                     1.258625 us
+                   4 MB                    1.499872 ms                   552.455250 us                   969.125000 ns
+                   8 MB                    3.127564 ms                     1.076804 ms                     1.603250 us
+                  16 MB                    5.524879 ms                     1.899661 ms                   648.000000 ns
+                  32 MB                    9.836432 ms                     3.396039 ms                   730.750000 ns
+                  64 MB                   15.650938 ms                     6.069018 ms                     1.148250 us
+                 128 MB                   18.723169 ms                    10.971188 ms                     1.871750 us
+                 256 MB                   32.749660 ms                    21.564225 ms                     3.174125 us
+                 512 MB                   61.956078 ms                    42.942366 ms                     2.200125 us
+                1024 MB                  123.413433 ms                    83.530199 ms                     1.155125 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=4
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  506.508000 us                   203.766750 us                     1.356250 us
+                   2 MB                  837.958125 us                   278.578625 us                     1.731750 us
+                   4 MB                    1.546308 ms                   576.977875 us                     1.151375 us
+                   8 MB                    2.524301 ms                     1.061731 ms                     1.648500 us
+                  16 MB                    4.285972 ms                     1.953383 ms                   718.250000 ns
+                  32 MB                    7.319340 ms                     3.144723 ms                   785.500000 ns
+                  64 MB                   12.537320 ms                     6.331435 ms                   981.875000 ns
+                 128 MB                   14.435122 ms                    11.271371 ms                     1.870750 us
+                 256 MB                   23.267783 ms                    21.478793 ms                     2.205375 us
+                 512 MB                   44.550463 ms                    42.958929 ms                     2.074250 us
+                1024 MB                   87.935820 ms                    83.861408 ms                     1.289500 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=8
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  870.483125 us                   187.190625 us                     1.251125 us
+                   2 MB                    1.508372 ms                   316.221125 us                     1.891500 us
+                   4 MB                    2.113352 ms                   682.485125 us                     1.983875 us
+                   8 MB                    3.727835 ms                     1.104546 ms                     1.586875 us
+                  16 MB                    5.643806 ms                     1.971286 ms                     1.438000 us
+                  32 MB                    9.390062 ms                     3.753546 ms                     1.002125 us
+                  64 MB                   13.937508 ms                     6.169532 ms                     1.561625 us
+                 128 MB                   16.372279 ms                    11.216718 ms                     1.925375 us
+                 256 MB                   27.431491 ms                    21.480846 ms                     2.435125 us
+                 512 MB                   52.565492 ms                    43.762668 ms                     1.989000 us
+                1024 MB                  104.741443 ms                    83.498288 ms                     1.402000 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=16
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    3.329761 ms                   240.807375 us                   859.125000 ns
+                   2 MB                    5.913015 ms                   550.045250 us                     1.404000 us
+                   4 MB                    7.884556 ms                   835.023375 us                     2.029750 us
+                   8 MB                    9.328399 ms                     1.370686 ms                     1.551750 us
+                  16 MB                   11.553297 ms                     1.869081 ms                   825.250000 ns
+                  32 MB                   16.870859 ms                     2.848457 ms                     1.110250 us
+                  64 MB                   20.134988 ms                     5.629939 ms                     1.897625 us
+                 128 MB                   33.664087 ms                    10.947977 ms                     2.285125 us
+                 256 MB                   62.258975 ms                    21.575464 ms                     2.707000 us
+                 512 MB                  121.081411 ms                    42.869413 ms                     2.246250 us
+                1024 MB                  241.314097 ms                    83.418688 ms                   973.000000 ns
 ```

--- a/results/intel_gpu.md
+++ b/results/intel_gpu.md
@@ -4,6 +4,101 @@ Built using
 BLAKE3_SIMD_LANES={2,4,8,16} make aot_gpu
 ```
 
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+Benchmarking BLAKE3 SYCL implementation (v1)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  206.908000 us                   279.064500 us                     1.358500 us
+                   2 MB                  269.451000 us                   556.263500 us                     1.306500 us
+                   4 MB                  416.468000 us                     1.112813 ms                     1.319500 us
+                   8 MB                  726.752000 us                     2.230943 ms                     1.306500 us
+                  16 MB                    1.345435 ms                     4.456166 ms                     1.326000 us
+                  32 MB                    2.553941 ms                     8.902653 ms                     1.352000 us
+                  64 MB                    4.974242 ms                    17.749401 ms                     1.319500 us
+                 128 MB                    9.812348 ms                    35.475108 ms                     1.319500 us
+                 256 MB                   19.465823 ms                    70.886068 ms                     1.293500 us
+                 512 MB                   39.271700 ms                   141.716997 ms                     1.313000 us
+                1024 MB                   77.556440 ms                   283.341799 ms                     1.534000 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=2
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  227.552000 us                   278.291000 us                     1.287000 us
+                   2 MB                  264.277000 us                   554.963500 us                     1.332500 us
+                   4 MB                  333.541000 us                     1.111337 ms                     1.300000 us
+                   8 MB                  507.754000 us                     2.226458 ms                     1.287000 us
+                  16 MB                  883.519000 us                     4.462686 ms                     1.319500 us
+                  32 MB                    1.641120 ms                     8.904168 ms                     1.365000 us
+                  64 MB                    3.106389 ms                    17.748458 ms                     1.365000 us
+                 128 MB                    6.047769 ms                    35.462187 ms                     1.306500 us
+                 256 MB                   11.941254 ms                    70.892191 ms                     1.326000 us
+                 512 MB                   24.103391 ms                   141.712876 ms                     1.306500 us
+                1024 MB                   47.515533 ms                   283.342299 ms                     1.319500 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=4
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    5.102851 ms                   279.233500 us                     1.397500 us
+                   2 MB                    5.229380 ms                   555.600500 us                     1.365000 us
+                   4 MB                    5.272852 ms                     1.116499 ms                     1.339000 us
+                   8 MB                    5.443074 ms                     2.232724 ms                     1.274000 us
+                  16 MB                    7.803627 ms                     4.467320 ms                     1.365000 us
+                  32 MB                   14.718652 ms                     8.905110 ms                     1.397500 us
+                  64 MB                   28.628951 ms                    17.749823 ms                     1.332500 us
+                 128 MB                   55.370055 ms                    35.462908 ms                     1.313000 us
+                 256 MB                  110.007846 ms                    70.894857 ms                     1.339000 us
+                 512 MB                  217.368879 ms                   141.709763 ms                     1.326000 us
+                1024 MB                  431.324205 ms                   283.344665 ms                     1.306500 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=8
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    9.324380 ms                   278.460000 us                     1.371500 us
+                   2 MB                    9.350029 ms                   554.996000 us                     1.300000 us
+                   4 MB                    9.575748 ms                     1.115653 ms                     1.365000 us
+                   8 MB                    9.677213 ms                     2.231476 ms                     1.293500 us
+                  16 MB                   11.115767 ms                     4.458499 ms                     1.332500 us
+                  32 MB                   26.391196 ms                     8.902127 ms                     1.352000 us
+                  64 MB                   56.188691 ms                    17.748861 ms                     1.326000 us
+                 128 MB                  128.767808 ms                    35.488212 ms                     1.339000 us
+                 256 MB                  245.655891 ms                    70.883748 ms                     1.391000 us
+                 512 MB                  476.839155 ms                   141.710504 ms                     1.326000 us
+                1024 MB                  938.669251 ms                   283.345946 ms                     2.164500 us
+```
+
+```bash
+# compiled using BLAKE3_SIMD_LANES=16
+Benchmarking BLAKE3 SYCL implementation (v2)
+
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                   16.163628 ms                   278.291000 us                     1.378000 us
+                   2 MB                   16.559127 ms                   554.983000 us                     1.332500 us
+                   4 MB                   16.669354 ms                     1.114230 ms                     1.358500 us
+                   8 MB                   18.026554 ms                     2.226952 ms                     1.378000 us
+                  16 MB                   21.859695 ms                     4.447020 ms                     1.319500 us
+                  32 MB                   41.686437 ms                     8.904811 ms                     1.326000 us
+                  64 MB                  105.559818 ms                    17.749823 ms                     1.365000 us
+                 128 MB                  216.700575 ms                    35.476174 ms                     1.287000 us
+                 256 MB                  475.246200 ms                    70.886621 ms                     1.332500 us
+                 512 MB                  932.357764 ms                   141.704667 ms                     1.371500 us
+                1024 MB                     1.843786 s                   283.342267 ms                     2.164500 us
+```
+
+---
+
 ### On `Intel(R) UHD Graphics P630 [0x3e96]`
 
 ```bash
@@ -11,88 +106,88 @@ running on Intel(R) UHD Graphics P630 [0x3e96]
 
 Benchmarking BLAKE3 SYCL implementation (v1)
 
-              input size                  execution time
-                   1 MB                  537.051000 us
-                   2 MB                  554.108000 us
-                   4 MB                  966.410000 us
-                   8 MB                    1.559404 ms
-                  16 MB                    4.102192 ms
-                  32 MB                    5.176751 ms
-                  64 MB                    9.727143 ms
-                 128 MB                   18.788544 ms
-                 256 MB                   36.848597 ms
-                 512 MB                   72.139408 ms
-                1024 MB                  145.486342 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  403.566750 us                    86.320000 us                     5.395000 us
+                   2 MB                  702.138500 us                   117.984500 us                     4.357500 us
+                   4 MB                    1.217153 ms                   191.750750 us                     4.502750 us
+                   8 MB                    2.193814 ms                   621.213500 us                    12.968750 us
+                  16 MB                    3.999957 ms                     1.343189 ms                     7.739750 us
+                  32 MB                    7.448918 ms                     3.384491 ms                     4.523500 us
+                  64 MB                   14.436294 ms                     5.935828 ms                     5.976000 us
+                 128 MB                   28.348629 ms                    12.623117 ms                     5.602500 us
+                 256 MB                   56.290641 ms                    21.704043 ms                     5.498750 us
+                 512 MB                  111.882983 ms                    42.580390 ms                     6.328750 us
+                1024 MB                  223.132739 ms                    60.189857 ms                     8.611250 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=2
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                  589.756000 us
-                   2 MB                  663.419000 us
-                   4 MB                    1.204828 ms
-                   8 MB                    2.190868 ms
-                  16 MB                    3.998027 ms
-                  32 MB                    7.314458 ms
-                  64 MB                   20.172154 ms
-                 128 MB                   27.232466 ms
-                 256 MB                   53.998555 ms
-                 512 MB                  115.996691 ms
-                1024 MB                  213.364157 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  413.091000 us                    79.431000 us                    12.844250 us
+                   2 MB                  483.910750 us                   120.204750 us                    12.802750 us
+                   4 MB                  947.943000 us                   186.687750 us                    12.885750 us
+                   8 MB                    1.681455 ms                   573.509250 us                    13.010250 us
+                  16 MB                    3.051184 ms                     1.336570 ms                    13.072500 us
+                  32 MB                    5.650578 ms                     2.657017 ms                    12.968750 us
+                  64 MB                   10.648153 ms                     5.967140 ms                    12.948000 us
+                 128 MB                   20.820882 ms                    10.938300 ms                    10.893750 us
+                 256 MB                   41.282789 ms                    19.979739 ms                     5.498750 us
+                 512 MB                   82.030684 ms                    30.104619 ms                     8.341500 us
+                1024 MB                  161.822216 ms                    59.488652 ms                     5.540250 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=4
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                   14.836167 ms
-                   2 MB                   10.452646 ms
-                   4 MB                   11.759108 ms
-                   8 MB                   38.073220 ms
-                  16 MB                   59.713727 ms
-                  32 MB                  112.923492 ms
-                  64 MB                  146.802141 ms
-                 128 MB                  178.022010 ms
-                 256 MB                  316.222571 ms
-                 512 MB                  640.830176 ms
-                1024 MB                     1.264373 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    4.147448 ms                    70.176500 us                     6.474000 us
+                   2 MB                    4.511714 ms                    86.340750 us                     5.166750 us
+                   4 MB                    5.211674 ms                   185.069250 us                     5.353500 us
+                   8 MB                   10.751135 ms                   575.542750 us                     4.565000 us
+                  16 MB                   20.591345 ms                     1.490701 ms                     4.689500 us
+                  32 MB                   37.061741 ms                     3.040622 ms                     6.515500 us
+                  64 MB                   70.038409 ms                     5.961600 ms                     6.702250 us
+                 128 MB                  135.915177 ms                     7.712111 ms                     6.577750 us
+                 256 MB                  268.948137 ms                    15.139988 ms                     6.681500 us
+                 512 MB                  535.521976 ms                    36.160486 ms                     7.822750 us
+                1024 MB                     1.066891 s                    59.627657 ms                     8.798000 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=8
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                   15.560342 ms
-                   2 MB                   11.355520 ms
-                   4 MB                   12.293711 ms
-                   8 MB                   15.675878 ms
-                  16 MB                   35.710916 ms
-                  32 MB                   77.741867 ms
-                  64 MB                  160.861677 ms
-                 128 MB                  281.493836 ms
-                 256 MB                  555.355241 ms
-                 512 MB                     1.122544 s
-                1024 MB                     2.277012 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    8.870915 ms                    70.010500 us                     5.498750 us
+                   2 MB                    9.908063 ms                   101.820250 us                     5.104500 us
+                   4 MB                   10.823345 ms                   193.659750 us                     6.225000 us
+                   8 MB                   13.922835 ms                   578.323250 us                     7.241750 us
+                  16 MB                   30.877660 ms                     1.238277 ms                     6.079750 us
+                  32 MB                   66.345884 ms                     2.846236 ms                     9.856250 us
+                  64 MB                  123.892606 ms                     4.746355 ms                     8.818750 us
+                 128 MB                  239.482701 ms                     7.742862 ms                     9.711000 us
+                 256 MB                  471.554270 ms                    15.200101 ms                     6.328750 us
+                 512 MB                  951.620439 ms                    36.128115 ms                    10.790000 us
+                1024 MB                     1.897564 s                    59.495666 ms                    13.010250 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=16
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                   23.753230 ms
-                   2 MB                   28.056946 ms
-                   4 MB                   30.302262 ms
-                   8 MB                   33.091104 ms
-                  16 MB                   51.108702 ms
-                  32 MB                  109.853861 ms
-                  64 MB                  245.284339 ms
-                 128 MB                  438.284737 ms
-                 256 MB                  850.511997 ms
-                 512 MB                     1.684447 s
-                1024 MB                     3.315495 s
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                   21.197121 ms                    84.473250 us                    11.661500 us
+                   2 MB                   25.279206 ms                   121.014000 us                    12.865000 us
+                   4 MB                   27.317707 ms                   193.369250 us                    11.827500 us
+                   8 MB                   30.231816 ms                   582.369500 us                    12.989500 us
+                  16 MB                   48.974295 ms                     1.260895 ms                    12.968750 us
+                  32 MB                  103.661314 ms                     2.298457 ms                    13.031000 us
+                  64 MB                  223.461170 ms                     3.978377 ms                    13.653500 us
+                 128 MB                  427.311265 ms                     7.710804 ms                    13.612000 us
+                 256 MB                  834.896523 ms                    16.717694 ms                    12.989500 us
+                 512 MB                     1.646072 s                    29.985472 ms                    12.906500 us
+                1024 MB                     3.256520 s                    59.557854 ms                    12.802750 us
 ```

--- a/results/nvidia_gpu.md
+++ b/results/nvidia_gpu.md
@@ -11,88 +11,88 @@ running on Tesla V100-SXM2-16GB
 
 Benchmarking BLAKE3 SYCL implementation (v1)
 
-              input size                  execution time
-                   1 MB                  158.310000 us
-                   2 MB                  170.454000 us
-                   4 MB                  194.167000 us
-                   8 MB                  253.067000 us
-                  16 MB                  317.383000 us
-                  32 MB                  500.367000 us
-                  64 MB                    1.036608 ms
-                 128 MB                    1.742003 ms
-                 256 MB                    3.257110 ms
-                 512 MB                    6.030942 ms
-                1024 MB                   10.450562 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  154.362875 us                   108.415750 us                     5.561750 us
+                   2 MB                  162.331625 us                   205.455875 us                     4.825500 us
+                   4 MB                  190.280500 us                   401.607625 us                     5.623000 us
+                   8 MB                  243.529875 us                   792.728250 us                     8.998750 us
+                  16 MB                  320.465750 us                     1.573578 ms                     6.149375 us
+                  32 MB                  482.268250 us                     3.118729 ms                     7.126000 us
+                  64 MB                  844.598250 us                     6.166145 ms                     6.973250 us
+                 128 MB                    1.800964 ms                    12.269974 ms                     7.080000 us
+                 256 MB                    3.267731 ms                    24.462952 ms                     6.805500 us
+                 512 MB                    5.998047 ms                    48.833740 ms                     6.713750 us
+                1024 MB                   11.915527 ms                    97.573730 ms                     8.423000 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=2
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                  193.848000 us
-                   2 MB                  193.847000 us
-                   4 MB                  204.101000 us
-                   8 MB                  254.150000 us
-                  16 MB                  331.543000 us
-                  32 MB                  476.318000 us
-                  64 MB                  875.978000 us
-                 128 MB                    1.810791 ms
-                 256 MB                    3.352050 ms
-                 512 MB                    6.414551 ms
-                1024 MB                   12.277342 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  189.209125 us                   467.285250 us                     5.370875 us
+                   2 MB                  191.650125 us                   205.322500 us                     4.882875 us
+                   4 MB                  204.345750 us                   401.611375 us                     5.859500 us
+                   8 MB                  248.046125 us                   792.968625 us                     5.859250 us
+                  16 MB                  341.796500 us                     1.574707 ms                     5.127250 us
+                  32 MB                  496.093000 us                     3.122803 ms                     7.080250 us
+                  64 MB                    1.016358 ms                     6.172363 ms                     7.568375 us
+                 128 MB                    1.838379 ms                    12.268555 ms                     7.568375 us
+                 256 MB                    3.539550 ms                    24.455078 ms                     7.080250 us
+                 512 MB                    6.729248 ms                    48.828125 ms                     7.079750 us
+                1024 MB                   11.715087 ms                    97.482910 ms                     9.765625 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=4
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                  328.124000 us
-                   2 MB                  302.979000 us
-                   4 MB                  320.800000 us
-                   8 MB                  338.134000 us
-                  16 MB                  429.443000 us
-                  32 MB                  592.529000 us
-                  64 MB                  967.529000 us
-                 128 MB                    1.975097 ms
-                 256 MB                    3.493408 ms
-                 512 MB                    6.756837 ms
-                1024 MB                   12.599365 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                  324.707250 us                   397.949125 us                     5.127250 us
+                   2 MB                  318.847625 us                   205.566625 us                     5.126750 us
+                   4 MB                  334.716500 us                   401.122875 us                     5.615500 us
+                   8 MB                  348.632875 us                   792.724625 us                     6.347250 us
+                  16 MB                  427.735250 us                     1.571533 ms                     5.615375 us
+                  32 MB                  622.559000 us                     3.118164 ms                     7.324125 us
+                  64 MB                  923.828375 us                     6.168457 ms                     7.323875 us
+                 128 MB                    2.014648 ms                    12.263916 ms                     7.568375 us
+                 256 MB                    4.190674 ms                    24.442871 ms                     7.080000 us
+                 512 MB                    7.277343 ms                    48.827637 ms                     6.836000 us
+                1024 MB                   12.184326 ms                    97.552734 ms                     8.300750 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=8
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    1.956297 ms
-                   2 MB                  677.489000 us
-                   4 MB                  688.965000 us
-                   8 MB                  710.692000 us
-                  16 MB                  737.060000 us
-                  32 MB                    1.019774 ms
-                  64 MB                    1.720215 ms
-                 128 MB                    4.105224 ms
-                 256 MB                   10.151125 ms
-                 512 MB                   19.336424 ms
-                1024 MB                   37.365477 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    1.199463 ms                   468.505875 us                     5.615250 us
+                   2 MB                  650.634750 us                   205.566500 us                     4.882750 us
+                   4 MB                  678.466625 us                   401.367375 us                     5.859125 us
+                   8 MB                  695.312125 us                   792.968750 us                     5.859125 us
+                  16 MB                  716.064500 us                     1.573974 ms                     6.103250 us
+                  32 MB                  928.221500 us                     3.122070 ms                     7.324375 us
+                  64 MB                    1.318848 ms                     6.168945 ms                     7.812625 us
+                 128 MB                    2.197510 ms                    12.266113 ms                     6.591625 us
+                 256 MB                    5.203370 ms                    24.459961 ms                     7.568250 us
+                 512 MB                   10.184327 ms                    48.817139 ms                     8.056625 us
+                1024 MB                   18.732911 ms                    97.577148 ms                     7.812250 us
 ```
 
 ```bash
 # compiled using BLAKE3_SIMD_LANES=16
 Benchmarking BLAKE3 SYCL implementation (v2)
 
-              input size                  execution time
-                   1 MB                    2.573731 ms
-                   2 MB                    1.459473 ms
-                   4 MB                    1.479737 ms
-                   8 MB                    1.520751 ms
-                  16 MB                    1.534669 ms
-                  32 MB                    1.673339 ms
-                  64 MB                    2.642822 ms
-                 128 MB                    5.867675 ms
-                 256 MB                   13.152344 ms
-                 512 MB                   27.395751 ms
-                1024 MB                   55.669432 ms
+              input size                  execution time                host-to-device tx time          device-to-host tx time
+                   1 MB                    2.113281 ms                   437.011750 us                     5.859250 us
+                   2 MB                    1.431641 ms                   205.322125 us                     5.127000 us
+                   4 MB                    1.480224 ms                   401.367250 us                     6.103625 us
+                   8 MB                    1.505371 ms                   792.236375 us                     6.103750 us
+                  16 MB                    1.516845 ms                     1.573974 ms                     5.615250 us
+                  32 MB                    1.594970 ms                     3.113770 ms                     7.324375 us
+                  64 MB                    2.055176 ms                     6.176270 ms                    10.254000 us
+                 128 MB                    5.214600 ms                    12.262207 ms                     7.323875 us
+                 256 MB                   13.925293 ms                    24.453369 ms                     7.568375 us
+                 512 MB                   27.458252 ms                    48.818115 ms                     7.812375 us
+                1024 MB                   52.898436 ms                    97.524170 ms                     8.056625 us
 ```

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Use this script to run test on all possible variants
+# of BLAKE3 implementation
+#
+# By variation, I mean proprocessor tricks employed to
+# decide which sources are finally compiled
+
+make clean
+
+BLAKE3_SIMD_LANES=2 make; make clean
+BLAKE3_SIMD_LANES=4 make; make clean
+BLAKE3_SIMD_LANES=8 make; make clean
+BLAKE3_SIMD_LANES=16 make; make clean

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -9,8 +9,12 @@ rust_blake3(uint8_t* input, uint64_t i_size);
 int
 main()
 {
-  sycl::device d{ sycl::default_selector{} };
-  sycl::queue q{ d };
+  sycl::default_selector sel{};
+  sycl::device d{ sel };
+  // using explicit context, instead of relying on default context created by
+  // sycl::queue
+  sycl::context ctx{ d };
+  sycl::queue q{ ctx, d };
 
   const size_t chunk_count = 1 << 10;
   const size_t wg_size = 1 << 6;


### PR DESCRIPTION
- I've refactored code little bit to reuse logic
- Added hints in source ( such as `#pragma unroll _` ) so that compiler can better optimize source
- Those variable declarations which can be made constant, I've made them constant
- Now I'm also timing host <-> device data transfer cost to get better picture of whether using this implementation really benefits us or not ( see `./results` directory )
- Added easy to use shell script, so that running test cases become easier, when SYCL implementation toolchain is installed on host